### PR TITLE
Fix CI: use uv venv instead of --system

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,19 +21,19 @@ jobs:
     - name: Set up Python
       run: uv python install 3.12
 
-    - name: Clean dist directory
+    - name: Create venv and install build tools
       run: |
-        rm -rf dist/* || true
+        uv venv
+        uv pip install build twine
+
+    - name: Clean dist directory
+      run: rm -rf dist/* || true
 
     - name: Build package
-      run: |
-        uv pip install --system build
-        python -m build
+      run: uv run python -m build
 
     - name: Verify package
-      run: |
-        uv pip install --system twine
-        python -m twine check dist/*
+      run: uv run python -m twine check dist/*
 
     - name: Publish to PyPI
       env:
@@ -41,7 +41,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
         set -e
-        python -m twine upload dist/* || {
+        uv run python -m twine upload dist/* || {
           status=$?
           echo "Twine upload failed with status $status"
           if [ "$status" -eq 1 ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,22 +19,21 @@ jobs:
     - name: Set up Python
       run: uv python install 3.12
 
-    - name: Clean dist directory
+    - name: Create venv and install
       run: |
-        rm -rf dist/* || true
+        uv venv
+        uv pip install build pytest pytest-asyncio
 
-    - name: Install dependencies and build
-      run: |
-        uv pip install --system build
-        python -m build
+    - name: Clean dist directory
+      run: rm -rf dist/* || true
+
+    - name: Build package
+      run: uv run python -m build
 
     - name: Test package installation
       run: |
-        uv pip install --system dist/*.whl || uv pip install --system dist/*.tar.gz
-        python -c "import qlik_sense_mcp_server; import importlib; importlib.import_module('qlik_sense_mcp_server.server'); print('OK')"
-
-    - name: Install test dependencies
-      run: uv pip install --system pytest pytest-asyncio
+        uv pip install dist/*.whl || uv pip install dist/*.tar.gz
+        uv run python -c "import qlik_sense_mcp_server; import importlib; importlib.import_module('qlik_sense_mcp_server.server'); print('OK')"
 
     - name: Run tests
-      run: pytest tests/ -v
+      run: uv run pytest tests/ -v

--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,6 @@ config.local.py
 
 # Bump2version
 .bumpversion.cfg.bak
+
+.claude
+claude.md


### PR DESCRIPTION
## Summary
- Ubuntu runners have externally-managed Python, causing `uv pip install --system` to fail
- Switch to `uv venv` + `uv pip install` + `uv run` pattern in both test and publish workflows
- Add `.claude` and `claude.md` to `.gitignore`

## Test plan
- [x] Build and Test workflow passes on PR
- [ ] After merge + re-tag, Publish to PyPI workflow passes