### PR TITLE
feat: JWT authentication via virtual proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,13 @@ certs/
 *.key
 *.crt
 
+# JWT signing keys and analyst token handouts — never commit
+jwt_keys/
+users/
+
+# MCP client artefacts
+.playwright-mcp/
+
 # Local configuration
 .env.local
 config.local.py

--- a/docs/AUTH_JWT.md
+++ b/docs/AUTH_JWT.md
@@ -71,8 +71,11 @@ python tools/qlik_jwt_admin.py issue-token \
 
 `--user-id` and `--user-directory` must match the values Qlik uses for that
 user (usually AD `sAMAccountName` and the domain short name). The defaults
-`--days 365`, `--user-id-claim userId`, and `--user-dir-claim userDirectory`
-match the QMC configuration above.
+`--days 90`, `--user-id-claim userId`, and `--user-dir-claim userDirectory`
+match the QMC configuration above. 90 days is a compromise between
+rotation discipline and operational overhead — bearer JWTs cannot be
+individually revoked, so pick the shortest lifetime you are willing to
+maintain.
 
 The CLI prints a ready-to-paste token plus the `env` block for the analyst's
 MCP config.
@@ -84,7 +87,7 @@ python tools/qlik_jwt_admin.py issue-token \
     --key ./jwt_keys/jwt_private.pem \
     --user-id svc_ai \
     --user-directory COMPANY \
-    --days 3650
+    --days 365
 ```
 
 For scripting:
@@ -160,6 +163,7 @@ something non-standard.
 | `QLIK_JWT_USER_ID_CLAIM` | Name of the payload claim holding the user id | `userId` |
 | `QLIK_JWT_USER_DIR_CLAIM` | Name of the payload claim holding the user directory | `userDirectory` |
 | `QLIK_JWT_SESSION_COOKIE` | Exact name of the VP session cookie | auto-detected from bootstrap response |
+| `QLIK_JWT_SESSION_TTL` | Seconds to cache the bootstrapped session before re-fetching. Lower this if the QMC Proxy `Session inactivity timeout` is below 30 min. | `1500` (25 min) |
 | `QLIK_VERIFY_SSL` | `false` disables TLS verification | `true` |
 | `QLIK_CA_CERT_PATH` | Path to a corporate CA bundle | unset |
 
@@ -271,12 +275,13 @@ each subsequent call.
   power. Keep it on one machine, back it up offline, and rotate it if you
   suspect any compromise.
 - Analysts only ever hold a signed JWT. A stolen JWT lets the attacker act
-  as *that one analyst* until the token expires (default 365 days) or the
+  as *that one analyst* until the token expires (default 90 days) or the
   user account is disabled in Qlik. It does not let them forge tokens for
   other users — they do not have the signing key.
 - Use separate virtual proxies for separate trust domains (e.g. dev vs
   prod). Each VP has its own certificate, so compromising one does not
   affect the other.
-- `--days 3650` exists for convenience but tilts the tradeoff toward
-  availability, not rotation discipline. The conservative default is 365.
-  Pick what matches your policy.
+- `--days 365` or higher exists for service tokens but tilts the tradeoff
+  toward availability over rotation discipline. Pick what matches your
+  policy; the default of 90 is deliberately short because bearer tokens
+  have no individual revocation path.

--- a/docs/AUTH_JWT.md
+++ b/docs/AUTH_JWT.md
@@ -1,0 +1,277 @@
+# JWT authentication for qlik-sense-mcp
+
+This mode lets an analyst use `qlik-sense-mcp-server` from their own Cursor /
+Claude Code instance with **nothing on disk but a bearer token string**. No
+client certificates, no private keys, no service account credentials. All
+secrets stay with the admin who runs `tools/qlik_jwt_admin.py`.
+
+The admin signs long-lived JWTs with a private key that lives only on the
+admin's machine. Each JWT encodes a single analyst's domain identity. The
+analyst copies the token into two environment variables of their MCP config —
+that is it. Qlik applies that analyst's own security rules, stream
+membership, and Section Access automatically.
+
+Certificate mode (legacy) still works unchanged for admins who need full QRS
+access to the Qlik server. JWT mode is selected automatically when
+`QLIK_JWT_TOKEN` is set in the environment.
+
+---
+
+## Part 1 — What the admin does once
+
+### 1.1 Generate the signing keys
+
+```bash
+python tools/qlik_jwt_admin.py init-keys --out ./jwt_keys
+```
+
+This produces three files in `./jwt_keys/`:
+
+| File | Purpose | Lives where |
+|---|---|---|
+| `jwt_private.pem` | Private RSA key, used to sign tokens | Admin machine only. Never copy to analysts. |
+| `jwt_public.pem` | Public key (informational) | Anywhere — not sensitive. |
+| `jwt_cert.pem` | Self-signed X.509 certificate with the public key | Pasted once into QMC. |
+
+Keep `jwt_private.pem` safe. Anyone who obtains it can impersonate any user
+in the configured virtual proxy until you rotate the key in QMC.
+
+### 1.2 Create a JWT virtual proxy in QMC
+
+Open `https://<your-qlik-host>/qmc` → **Configure system** → **Virtual
+proxies** → **Create new** and fill in the following values. Every value
+marked *default* matches what the MCP assumes out of the box — change it
+only if you have a good reason.
+
+| Field | Value | Notes |
+|---|---|---|
+| **Description** | `JWT for qlik-sense-mcp` | Free-form. |
+| **Prefix** | `jwt` *(default)* | Lowercase. Must match the URL path you give analysts in `QLIK_SERVER_URL`. |
+| **Session cookie header name** | `X-Qlik-Session-jwt` *(default)* | Must be unique across virtual proxies. The MCP auto-detects this from `Set-Cookie`, so the exact name is not critical — any `X-Qlik-Session*` works. |
+| **Authentication method** | `JWT` | |
+| **JWT certificate** | Paste the full contents of `./jwt_keys/jwt_cert.pem`, including the `-----BEGIN CERTIFICATE-----` lines | |
+| **JWT attribute for user ID** | `userId` *(default)* | Must match `--user-id-claim` when issuing tokens. |
+| **JWT attribute for user directory** | `userDirectory` *(default)* | Must match `--user-dir-claim`. |
+| **Load balancing** → **Load balancing nodes** | Select your Engine node (usually Central) | |
+| **Advanced** → **Host allow list** | Add the exact hostname your analysts will put into `QLIK_SERVER_URL`, e.g. `qlik.company.com` | **Hostname only**, no scheme, no port, no IP addresses. Origin validation is strict. |
+| **Link** | Link the virtual proxy to **every** Proxy service whose hostname is in the Host allow list above — and **always also to the Central Proxy**, even when analysts will never hit the Central hostname. | In a multi-node cluster, any prefixed VP that is not linked to the Central Proxy is rejected by all proxy services with HTTP 400 ("The http request header is incorrect") regardless of whether the receiving node has its own link. Single-node deployments get this for free. |
+
+Save. Wait 10–30 seconds for the proxy to restart.
+
+### 1.3 Issue a token for an analyst
+
+For each analyst you want to enable:
+
+```bash
+python tools/qlik_jwt_admin.py issue-token \
+    --key ./jwt_keys/jwt_private.pem \
+    --user-id ivanov \
+    --user-directory COMPANY
+```
+
+`--user-id` and `--user-directory` must match the values Qlik uses for that
+user (usually AD `sAMAccountName` and the domain short name). The defaults
+`--days 365`, `--user-id-claim userId`, and `--user-dir-claim userDirectory`
+match the QMC configuration above.
+
+The CLI prints a ready-to-paste token plus the `env` block for the analyst's
+MCP config.
+
+For long-lived service tokens, pass a larger value:
+
+```bash
+python tools/qlik_jwt_admin.py issue-token \
+    --key ./jwt_keys/jwt_private.pem \
+    --user-id svc_ai \
+    --user-directory COMPANY \
+    --days 3650
+```
+
+For scripting:
+
+```bash
+TOKEN=$(python tools/qlik_jwt_admin.py issue-token --key ... --user-id ivanov --user-directory COMPANY --quiet)
+```
+
+### 1.4 Revocation
+
+Qlik does not provide per-token revocation. Your options are:
+
+- **Standard case — the analyst leaves or changes role.** Disable or remove
+  the domain user in Qlik (via QMC or AD sync). A valid JWT for a disabled
+  user is rejected by the Qlik proxy — no MCP change required.
+
+- **Emergency — the signing key is compromised.** Generate a new keypair
+  (`init-keys --out ./jwt_keys_new`), paste the new `jwt_cert.pem` into the
+  virtual proxy, reissue tokens for everyone. Replacing the certificate in
+  QMC invalidates every token that was signed with the old key at once.
+
+---
+
+## Part 2 — What the analyst does
+
+### 2.1 Install
+
+Same as the regular install path. See `docs/installation.md`.
+
+### 2.2 Configure Cursor / Claude Code
+
+Add the following to the MCP config (e.g. `.cursor/mcp.json` or the
+equivalent for your client):
+
+```json
+{
+  "mcpServers": {
+    "qlik": {
+      "command": "qlik-sense-mcp-server",
+      "args": ["--stdio"],
+      "env": {
+        "QLIK_SERVER_URL": "https://qlik.company.com/jwt",
+        "QLIK_JWT_TOKEN": "eyJhbGciOiJSUzI1NiJ9...."
+      }
+    }
+  }
+}
+```
+
+Two variables — that is the whole configuration.
+
+- **`QLIK_SERVER_URL`** — the Qlik hostname with the virtual proxy prefix as
+  URL path. If the admin used the default prefix `jwt`, the path is `/jwt`.
+- **`QLIK_JWT_TOKEN`** — the token string the admin gave you. Treat it like
+  a password.
+
+Restart Cursor. The MCP server connects to Qlik on first tool call, all
+operations run under the analyst's own Qlik identity, and Qlik security
+rules apply normally.
+
+### 2.3 Optional overrides
+
+You do not normally need these. Use them only if your admin configured
+something non-standard.
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `QLIK_JWT_USER_ID_CLAIM` | Name of the payload claim holding the user id | `userId` |
+| `QLIK_JWT_USER_DIR_CLAIM` | Name of the payload claim holding the user directory | `userDirectory` |
+| `QLIK_JWT_SESSION_COOKIE` | Exact name of the VP session cookie | auto-detected from bootstrap response |
+| `QLIK_VERIFY_SSL` | `false` disables TLS verification | `true` |
+| `QLIK_CA_CERT_PATH` | Path to a corporate CA bundle | unset |
+
+---
+
+## How it works under the hood
+
+The MCP performs a two-phase handshake the first time a tool needs Qlik.
+
+**Phase 1** — the MCP calls `GET https://<host>/<vp_prefix>/qps/csrftoken`
+with `Authorization: Bearer <jwt>`. The Qlik virtual proxy validates the JWT
+against the certificate configured in QMC, creates a session, and returns:
+
+- `Set-Cookie: X-Qlik-Session-<prefix>=<value>`
+- HTTP header `qlik-csrf-token: <value>`
+
+**Phase 2** — every subsequent request carries the session cookie. HTTP QRS
+calls also include `qlik-csrf-token`. The Engine WebSocket upgrade sends
+the cookie, the CSRF token **both as a header and appended to the URL as
+`?qlik-csrf-token=<value>` query parameter**, and an `Origin` header
+pointing at the Qlik host — but **not** `Authorization: Bearer`, because
+Qlik November 2024+ rejects that on WebSocket upgrades under its CSWSH
+protection. Empirically, the query-parameter form of the CSRF token is what
+Qlik actually validates on the WS upgrade; sending it only as a header
+still returns 403. This two-phase flow is Qlik's official path and is safe
+on older versions too (the extra header/query is simply ignored
+pre-November 2024).
+
+The MCP re-bootstraps automatically on session expiry (every ~25 minutes or
+on a 401 response).
+
+---
+
+## Troubleshooting
+
+### `csrftoken returned 401 — JWT rejected by the virtual proxy`
+
+Most common causes:
+
+1. **The token is expired.** Check the `exp` claim. Reissue with a larger
+   `--days`.
+2. **Clock skew.** The `iat` claim is backdated 30 s by `issue-token` to
+   mitigate small skew. If the Qlik server is more than that ahead of the
+   admin's machine, sync NTP.
+3. **Claim name mismatch.** The QMC "JWT attribute for user ID / user
+   directory" fields must exactly match `--user-id-claim` /
+   `--user-dir-claim` (case-sensitive). Defaults are `userId` /
+   `userDirectory`.
+4. **Wrong certificate in QMC.** If you regenerated keys but forgot to paste
+   the new `jwt_cert.pem`, the VP still trusts the old key and rejects the
+   newly-signed tokens.
+5. **User unknown to Qlik.** The payload `userId` / `userDirectory` must
+   identify a user that Qlik recognizes. Disabled / nonexistent users are
+   rejected.
+
+### `csrftoken returned 400 — VP is not linked to Central Proxy`
+
+In a multi-node Qlik cluster, any request to a prefixed virtual proxy
+whose VP is not linked to the Central Proxy is answered with HTTP 400
+"The http request header is incorrect" — a ~88 KB styled Qlik error page,
+identical across all prefixes and even for prefixes that do not exist.
+The fix is to link the JWT VP to the Central Proxy in QMC (Proxies →
+Central → Associated items → Virtual proxies → Link), in addition to any
+node-specific proxy that hosts the public hostname. See section 1.2 above.
+
+### `csrftoken returned 403 — VP refused the request`
+
+Host allow list mismatch. Add the exact hostname from `QLIK_SERVER_URL` to
+the virtual proxy's **Advanced → Host allow list** in QMC. Hostname only, no
+scheme, no port, no IP.
+
+### WebSocket fails with `Handshake status 403 Forbidden`
+
+On Qlik November 2024+ the WebSocket upgrade is rejected under CSWSH
+protection when the `qlik-csrf-token` is only sent as an HTTP header.
+The MCP appends it as a `?qlik-csrf-token=<value>` query parameter to the
+WS URL (that is what Qlik actually validates) and also sends it as a
+header for backward compatibility. If you are running the MCP built-in
+then this is already correct — a 403 here means either the VP is not
+linked to the Central Proxy (see 400 entry above, which sometimes
+surfaces as a 403 on WS), or the hostname in `QLIK_SERVER_URL` does not
+match an entry in the VP Host allow list.
+
+### `JWT mode requires a virtual proxy prefix in QLIK_SERVER_URL`
+
+You set `QLIK_JWT_TOKEN` but `QLIK_SERVER_URL` has no path. Add the prefix:
+
+```
+QLIK_SERVER_URL=https://qlik.company.com/jwt
+```
+
+### Everything looks right but requests still fail
+
+Turn on debug logging in the MCP:
+
+```
+LOG_LEVEL=DEBUG qlik-sense-mcp-server --stdio
+```
+
+The log shows the exact bootstrap URL, the session cookie name that was
+picked up, whether `qlik-csrf-token` was received, and the HTTP status of
+each subsequent call.
+
+---
+
+## Security notes
+
+- `jwt_private.pem` is the only secret that grants admin-level impersonation
+  power. Keep it on one machine, back it up offline, and rotate it if you
+  suspect any compromise.
+- Analysts only ever hold a signed JWT. A stolen JWT lets the attacker act
+  as *that one analyst* until the token expires (default 365 days) or the
+  user account is disabled in Qlik. It does not let them forge tokens for
+  other users — they do not have the signing key.
+- Use separate virtual proxies for separate trust domains (e.g. dev vs
+  prod). Each VP has its own certificate, so compromising one does not
+  affect the other.
+- `--days 3650` exists for convenience but tilts the tradeoff toward
+  availability, not rotation discipline. The conservative default is 365.
+  Pick what matches your policy.

--- a/docs/AUTH_JWT.md
+++ b/docs/AUTH_JWT.md
@@ -123,8 +123,8 @@ equivalent for your client):
 {
   "mcpServers": {
     "qlik": {
-      "command": "qlik-sense-mcp-server",
-      "args": ["--stdio"],
+      "command": "uvx",
+      "args": ["qlik-sense-mcp-server"],
       "env": {
         "QLIK_SERVER_URL": "https://qlik.company.com/jwt",
         "QLIK_JWT_TOKEN": "eyJhbGciOiJSUzI1NiJ9...."
@@ -133,6 +133,11 @@ equivalent for your client):
   }
 }
 ```
+
+`uvx` comes with [uv](https://docs.astral.sh/uv/). If the analyst does not
+have it yet, install once: `pip install uv` (or via the OS package
+manager). No global install of `qlik-sense-mcp-server` is required — uvx
+fetches and runs it in an isolated throw-away environment on each start.
 
 Two variables — that is the whole configuration.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ dependencies = [
     "httpx>=0.25.0",
     "pydantic>=2.0.0",
     "python-dotenv>=1.0.0",
-    "websocket-client>=1.6.0"
+    "websocket-client>=1.6.0",
+    "PyJWT[crypto]>=2.8.0",
+    "cryptography>=41.0.0"
 ]
 requires-python = ">=3.12"
 

--- a/qlik_sense_mcp_server/config.py
+++ b/qlik_sense_mcp_server/config.py
@@ -2,6 +2,7 @@
 
 import os
 from typing import Optional
+from urllib.parse import urlparse
 from pydantic import BaseModel, Field
 
 
@@ -33,37 +34,156 @@ MAX_FIELD_FETCH_SIZE = 5000
 MAX_TABLES_AND_KEYS_DIM = 1000
 MAX_TABLES = 50
 
+# JWT defaults (mirror Qlik's own JWT virtual proxy examples and docs/AUTH_JWT.md)
+DEFAULT_JWT_USER_ID_CLAIM = "userId"
+DEFAULT_JWT_USER_DIR_CLAIM = "userDirectory"
+
+# Authentication modes
+AUTH_MODE_CERTIFICATE = "certificate"
+AUTH_MODE_JWT = "jwt"
+
 
 class QlikSenseConfig(BaseModel):
     """
     Configuration model for Qlik Sense Enterprise server connection.
 
-    Handles server connection details, authentication credentials,
-    certificate paths, and API endpoint configuration.
+    Supports two authentication modes, selected automatically based on which
+    environment variables are provided:
+
+    1. ``certificate`` (default, legacy) — client certificate + X-Qlik-User
+       header impersonation directly against ports 4242 (QRS) and 4747
+       (Engine). Suitable for admin/service use on the Qlik server host.
+
+    2. ``jwt`` — bearer JWT signed by the admin with a private key whose
+       certificate is installed on a Qlik JWT virtual proxy. Each analyst
+       receives only a long-lived token and talks to Qlik via the VP
+       (standard HTTPS/WSS on 443). Recommended for end users.
+
+    The mode is selected by presence of QLIK_JWT_TOKEN in the environment:
+
+        QLIK_JWT_TOKEN set  → jwt mode
+        otherwise           → certificate mode
     """
 
-    server_url: str = Field(..., description="Qlik Sense server URL (e.g., https://qlik.company.com)")
-    user_directory: str = Field(..., description="User directory for authentication")
-    user_id: str = Field(..., description="User ID for authentication")
-    client_cert_path: Optional[str] = Field(None, description="Path to client certificate")
-    client_key_path: Optional[str] = Field(None, description="Path to client private key")
-    ca_cert_path: Optional[str] = Field(None, description="Path to CA certificate")
-    repository_port: int = Field(DEFAULT_REPOSITORY_PORT, description="Repository API port")
-    proxy_port: int = Field(DEFAULT_PROXY_PORT, description="Proxy API port")
-    engine_port: int = Field(DEFAULT_ENGINE_PORT, description="Engine API port")
-    http_port: Optional[int] = Field(None, description="HTTP API port for metadata requests")
+    # Common
+    server_url: str = Field(..., description="Qlik Sense server URL. In JWT mode include the "
+                                             "virtual proxy prefix as URL path, e.g. "
+                                             "'https://qlik.company.com/jwt'.")
+    user_directory: str = Field("", description="User directory for X-Qlik-User (certificate mode)")
+    user_id: str = Field("", description="User ID for X-Qlik-User (certificate mode)")
     verify_ssl: bool = Field(True, description="Verify SSL certificates")
+    ca_cert_path: Optional[str] = Field(None, description="Path to CA certificate (optional, both modes)")
+
+    # Certificate mode
+    client_cert_path: Optional[str] = Field(None, description="Path to client certificate (certificate mode)")
+    client_key_path: Optional[str] = Field(None, description="Path to client private key (certificate mode)")
+    repository_port: int = Field(DEFAULT_REPOSITORY_PORT, description="Repository API port (certificate mode)")
+    proxy_port: int = Field(DEFAULT_PROXY_PORT, description="Proxy API port (certificate mode)")
+    engine_port: int = Field(DEFAULT_ENGINE_PORT, description="Engine API port (certificate mode)")
+    http_port: Optional[int] = Field(None, description="HTTP API port for metadata requests (certificate mode)")
+
+    # JWT mode
+    jwt_token: Optional[str] = Field(None, description="Signed JWT bearer (jwt mode)")
+    jwt_user_id_claim: str = Field(DEFAULT_JWT_USER_ID_CLAIM,
+                                   description="JWT payload claim holding user id — must match QMC 'JWT "
+                                               "attribute for user ID'")
+    jwt_user_dir_claim: str = Field(DEFAULT_JWT_USER_DIR_CLAIM,
+                                    description="JWT payload claim holding user directory — must match "
+                                                "QMC 'JWT attribute for user directory'")
+    jwt_session_cookie_override: Optional[str] = Field(None,
+                                                       description="Optional override for the VP session cookie "
+                                                                   "name; when None the name is auto-detected from "
+                                                                   "the bootstrap response Set-Cookie header.")
+
+    @property
+    def auth_mode(self) -> str:
+        """
+        Resolve authentication mode from the presence of a JWT token.
+
+        The presence of ``jwt_token`` is the single source of truth — there
+        is no standalone ``QLIK_AUTH_MODE`` switch to keep the user-facing
+        surface minimal (one less env var to get wrong).
+        """
+        return AUTH_MODE_JWT if self.jwt_token else AUTH_MODE_CERTIFICATE
+
+    @property
+    def qlik_base_host(self) -> str:
+        """
+        Return ``scheme://host[:port]`` stripped of any URL path.
+
+        ``server_url`` may contain a virtual proxy prefix as path (JWT mode),
+        e.g. ``https://qlik.company.com/jwt``. All legacy URL builders (QRS
+        on 4242, Engine WSS on 4747) need the bare host without the prefix.
+        """
+        parsed = urlparse(self.server_url)
+        if not parsed.scheme or not parsed.hostname:
+            # Fall back to the raw value if it was given as bare host — the
+            # original certificate-mode code accepted this form.
+            return self.server_url.rstrip("/")
+        host = f"{parsed.scheme}://{parsed.hostname}"
+        if parsed.port:
+            host += f":{parsed.port}"
+        return host
+
+    @property
+    def qlik_hostname(self) -> str:
+        """Return just the hostname (no scheme, no port, no path)."""
+        parsed = urlparse(self.server_url)
+        if parsed.hostname:
+            return parsed.hostname
+        # Best-effort fallback for raw 'host' or 'host:port' values.
+        return self.server_url.replace("https://", "").replace("http://", "").split("/")[0].split(":")[0]
+
+    @property
+    def virtual_proxy_prefix(self) -> str:
+        """
+        Return the virtual proxy prefix embedded in ``server_url`` path.
+
+        ``https://qlik.company.com/jwt``    → ``"jwt"``
+        ``https://qlik.company.com``        → ``""``
+        ``https://qlik.company.com/a/b``    → ``"a/b"`` (multi-segment is
+        unusual for Qlik VPs but preserved verbatim if someone sets it).
+        """
+        parsed = urlparse(self.server_url)
+        return (parsed.path or "").strip("/")
+
+    def validate_runtime(self) -> None:
+        """
+        Validate the assembled configuration for the chosen auth mode.
+
+        Called once at startup from ``server._init_clients``. Raises
+        ``ValueError`` with a human-readable message that the CLI converts
+        into a clear log line the user can act on.
+        """
+        if not self.server_url:
+            raise ValueError("QLIK_SERVER_URL is required")
+
+        if self.auth_mode == AUTH_MODE_JWT:
+            if not self.virtual_proxy_prefix:
+                raise ValueError(
+                    "JWT mode requires a virtual proxy prefix in QLIK_SERVER_URL. "
+                    "Example: QLIK_SERVER_URL=https://qlik.company.com/jwt"
+                )
+            if not self.jwt_token:
+                raise ValueError("JWT mode requires QLIK_JWT_TOKEN")
+            # user_directory / user_id are intentionally NOT required in JWT
+            # mode — Qlik extracts the identity from the JWT payload itself.
+        else:
+            if not (self.user_directory and self.user_id):
+                raise ValueError(
+                    "certificate mode requires QLIK_USER_DIRECTORY and QLIK_USER_ID"
+                )
+            # client_cert/key are optional at the pydantic level (some
+            # deployments pre-configure them system-wide), but _create_httpx_client
+            # and engine_api.connect() handle both with/without cert.
 
     @classmethod
     def from_env(cls) -> "QlikSenseConfig":
         """
         Create configuration instance from environment variables.
 
-        Reads all required and optional configuration values from environment
-        variables with QLIK_ prefix and validates them.
-
-        Returns:
-            Configured QlikSenseConfig instance
+        The presence of ``QLIK_JWT_TOKEN`` selects JWT mode automatically —
+        no separate ``QLIK_AUTH_MODE`` variable is needed.
         """
         return cls(
             server_url=os.getenv("QLIK_SERVER_URL", ""),
@@ -76,5 +196,9 @@ class QlikSenseConfig(BaseModel):
             proxy_port=int(os.getenv("QLIK_PROXY_PORT", str(DEFAULT_PROXY_PORT))),
             engine_port=int(os.getenv("QLIK_ENGINE_PORT", str(DEFAULT_ENGINE_PORT))),
             http_port=int(os.getenv("QLIK_HTTP_PORT")) if os.getenv("QLIK_HTTP_PORT") else None,
-            verify_ssl=os.getenv("QLIK_VERIFY_SSL", "true").lower() == "true"
+            verify_ssl=os.getenv("QLIK_VERIFY_SSL", "true").lower() == "true",
+            jwt_token=os.getenv("QLIK_JWT_TOKEN") or None,
+            jwt_user_id_claim=os.getenv("QLIK_JWT_USER_ID_CLAIM", DEFAULT_JWT_USER_ID_CLAIM),
+            jwt_user_dir_claim=os.getenv("QLIK_JWT_USER_DIR_CLAIM", DEFAULT_JWT_USER_DIR_CLAIM),
+            jwt_session_cookie_override=os.getenv("QLIK_JWT_SESSION_COOKIE") or None,
         )

--- a/qlik_sense_mcp_server/config.py
+++ b/qlik_sense_mcp_server/config.py
@@ -1,9 +1,12 @@
 """Configuration for Qlik Sense MCP Server."""
 
+import logging
 import os
 from typing import Optional
 from urllib.parse import urlparse
 from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
 
 
 # Default ports
@@ -142,7 +145,7 @@ class QlikSenseConfig(BaseModel):
         ``https://qlik.company.com/jwt``    → ``"jwt"``
         ``https://qlik.company.com``        → ``""``
         ``https://qlik.company.com/a/b``    → ``"a/b"`` (multi-segment is
-        unusual for Qlik VPs but preserved verbatim if someone sets it).
+        unusual for Qlik VPs — ``validate_runtime`` warns when it happens).
         """
         parsed = urlparse(self.server_url)
         return (parsed.path or "").strip("/")
@@ -158,11 +161,30 @@ class QlikSenseConfig(BaseModel):
         if not self.server_url:
             raise ValueError("QLIK_SERVER_URL is required")
 
+        parsed_server = urlparse(self.server_url)
+        if not parsed_server.scheme:
+            raise ValueError(
+                "QLIK_SERVER_URL must include a scheme (e.g. https://qlik.company.com)"
+            )
+        if parsed_server.scheme not in ("https", "http"):
+            raise ValueError(
+                f"QLIK_SERVER_URL scheme must be https or http, got "
+                f"{parsed_server.scheme!r}"
+            )
+
         if self.auth_mode == AUTH_MODE_JWT:
             if not self.virtual_proxy_prefix:
                 raise ValueError(
                     "JWT mode requires a virtual proxy prefix in QLIK_SERVER_URL. "
                     "Example: QLIK_SERVER_URL=https://qlik.company.com/jwt"
+                )
+            if "/" in self.virtual_proxy_prefix:
+                logger.warning(
+                    "QLIK_SERVER_URL has a multi-segment path %r — Qlik virtual "
+                    "proxies use a single-segment prefix. The MCP will pass the "
+                    "full path as-is; expect connection failures if Qlik does "
+                    "not recognize it.",
+                    self.virtual_proxy_prefix,
                 )
             if not self.jwt_token:
                 raise ValueError("JWT mode requires QLIK_JWT_TOKEN")

--- a/qlik_sense_mcp_server/engine_api.py
+++ b/qlik_sense_mcp_server/engine_api.py
@@ -12,8 +12,10 @@ from .config import (
     DEFAULT_HYPERCUBE_MAX_ROWS,
     MAX_TABLES_AND_KEYS_DIM,
     MAX_TABLES,
+    AUTH_MODE_JWT,
 )
 from .exceptions import QlikConnectionError, QlikEngineError
+from .jwt_session import JwtSession, JwtBootstrapError
 import logging
 import os
 
@@ -23,8 +25,9 @@ logger = logging.getLogger(__name__)
 class QlikEngineAPI:
     """Client for Qlik Sense Engine API using WebSocket."""
 
-    def __init__(self, config: QlikSenseConfig):
+    def __init__(self, config: QlikSenseConfig, jwt_session: Optional[JwtSession] = None):
         self.config = config
+        self.jwt_session = jwt_session  # required when config.auth_mode == jwt
         self.ws = None
         self.request_id = 0
         # Connection cache
@@ -54,6 +57,18 @@ class QlikEngineAPI:
         """
         Connect to Engine API via WebSocket.
 
+        In certificate mode, connects directly to the Engine port (4747) with
+        an X-Qlik-User impersonation header and a loaded client cert chain.
+
+        In JWT mode, goes through the virtual proxy on 443:
+        ``wss://<host>/<vp_prefix>/app/<app_guid>``. A bootstrap call to
+        ``/qps/csrftoken`` happens first (via ``JwtSession.ensure_standalone``)
+        so the WS upgrade can carry the resulting session cookie, the
+        ``qlik-csrf-token`` anti-CSWSH header, and a valid ``Origin`` — which
+        is what Qlik November 2024+ explicitly requires. We do NOT send
+        ``Authorization: Bearer`` on the upgrade request because CSWSH
+        protection rejects exactly that.
+
         If `app_id` is provided, the per-app endpoint `/app/<app_id>` is tried
         first — this is the Qlik-recommended way that binds the session to a
         specific document immediately and avoids an extra OpenDoc round-trip.
@@ -61,24 +76,54 @@ class QlikEngineAPI:
         that global calls (GetDocList, etc.) keep working.
         """
         from urllib.parse import quote
-        # Try different WebSocket endpoints
-        server_host = self.config.server_url.replace("https://", "").replace(
-            "http://", ""
-        )
+        is_jwt = self.config.auth_mode == AUTH_MODE_JWT
+        server_host = self.config.qlik_hostname
 
-        # Build endpoint list — per-app first if app_id is given
+        # In JWT mode the CSRF token must be appended to the WS URL as a query
+        # parameter — Qlik November 2024+ rejects the upgrade with 403 if the
+        # anti-CSWSH token is only sent as an HTTP header. Bootstrap the
+        # session up-front so we know the token value when building URLs.
+        jwt_csrf_qs = ""
+        if is_jwt:
+            if self.jwt_session is None:
+                raise ConnectionError(
+                    "JWT mode requires a JwtSession — check server._init_clients wiring."
+                )
+            try:
+                self.jwt_session.ensure_standalone()
+            except JwtBootstrapError as exc:
+                raise ConnectionError(f"JWT session bootstrap failed: {exc}") from exc
+            if self.jwt_session.csrf_token:
+                jwt_csrf_qs = f"?qlik-csrf-token={quote(self.jwt_session.csrf_token, safe='')}"
+
+        # Build endpoint list — per-app first if app_id is given.
         endpoints_all: List[str] = []
-        if app_id:
-            enc = quote(app_id, safe="")
-            endpoints_all.append(
-                f"wss://{server_host}:{self.config.engine_port}/app/{enc}"
-            )
-        endpoints_all.extend([
-            f"wss://{server_host}:{self.config.engine_port}/app/engineData",
-            f"wss://{server_host}:{self.config.engine_port}/app",
-            f"ws://{server_host}:{self.config.engine_port}/app/engineData",
-            f"ws://{server_host}:{self.config.engine_port}/app",
-        ])
+        if is_jwt:
+            # Via virtual proxy on 443. No ws:// fallback — TLS is mandatory
+            # because the JWT was minted against a TLS-protected Host allow
+            # list in QMC.
+            prefix = self.config.virtual_proxy_prefix
+            if app_id:
+                enc = quote(app_id, safe="")
+                endpoints_all.append(
+                    f"wss://{server_host}/{prefix}/app/{enc}{jwt_csrf_qs}"
+                )
+            endpoints_all.extend([
+                f"wss://{server_host}/{prefix}/app/engineData{jwt_csrf_qs}",
+                f"wss://{server_host}/{prefix}/app{jwt_csrf_qs}",
+            ])
+        else:
+            if app_id:
+                enc = quote(app_id, safe="")
+                endpoints_all.append(
+                    f"wss://{server_host}:{self.config.engine_port}/app/{enc}"
+                )
+            endpoints_all.extend([
+                f"wss://{server_host}:{self.config.engine_port}/app/engineData",
+                f"wss://{server_host}:{self.config.engine_port}/app",
+                f"ws://{server_host}:{self.config.engine_port}/app/engineData",
+                f"ws://{server_host}:{self.config.engine_port}/app",
+            ])
         # ws_retries controls how many fallback endpoints to try; always at
         # least 1, and if app_id is given we add +1 to include the per-app URL
         # without starving the fallback list.
@@ -91,7 +136,11 @@ class QlikEngineAPI:
             ssl_context.check_hostname = False
             ssl_context.verify_mode = ssl.CERT_NONE
 
-        if self.config.client_cert_path and self.config.client_key_path:
+        # In JWT mode we intentionally do NOT load a client certificate —
+        # auth is handled by the VP via the bearer token + session cookie.
+        if (not is_jwt
+                and self.config.client_cert_path
+                and self.config.client_key_path):
             ssl_context.load_cert_chain(
                 self.config.client_cert_path, self.config.client_key_path
             )
@@ -100,9 +149,27 @@ class QlikEngineAPI:
             ssl_context.load_verify_locations(self.config.ca_cert_path)
 
         # Headers for authentication
-        headers = [
-            f"X-Qlik-User: UserDirectory={self.config.user_directory}; UserId={self.config.user_id}"
-        ]
+        if is_jwt:
+            # jwt_session is already bootstrapped above — we needed the CSRF
+            # token at URL-build time.
+            headers = [
+                f"Cookie: {self.jwt_session.cookie_header()}",
+                # Send qlik-csrf-token both as a header and as a query
+                # parameter (appended to the URL above). Qlik November 2024+
+                # requires the query-parameter form for WebSocket upgrades —
+                # the header alone still 403s under CSWSH protection.
+                *([f"qlik-csrf-token: {self.jwt_session.csrf_token}"]
+                  if self.jwt_session.csrf_token else []),
+                # Origin must match an entry in the VP Host allow list from
+                # QMC. Qlik accepts the bare hostname entry and compares
+                # case-insensitively against the Origin hostname, so the
+                # canonical https://<hostname> form works.
+                f"Origin: https://{server_host}",
+            ]
+        else:
+            headers = [
+                f"X-Qlik-User: UserDirectory={self.config.user_directory}; UserId={self.config.user_id}"
+            ]
 
         last_error = None
         for url in endpoints_to_try:

--- a/qlik_sense_mcp_server/engine_api.py
+++ b/qlik_sense_mcp_server/engine_api.py
@@ -75,9 +75,16 @@ class QlikEngineAPI:
         The global `/app/engineData` endpoint is still tried as a fallback so
         that global calls (GetDocList, etc.) keep working.
         """
-        from urllib.parse import quote
+        from urllib.parse import quote, urlparse
         is_jwt = self.config.auth_mode == AUTH_MODE_JWT
-        server_host = self.config.qlik_hostname
+        # For JWT mode we preserve the full netloc (host + optional port) so
+        # deployments on non-standard ports like 8443 keep working.
+        # Certificate mode builds its own host:port below since it always
+        # appends the Engine port explicitly.
+        parsed_url = urlparse(self.config.server_url)
+        server_netloc = parsed_url.netloc or self.config.qlik_hostname
+        server_scheme = parsed_url.scheme or "https"
+        server_host = self.config.qlik_hostname  # bare hostname, used for cert mode
 
         # In JWT mode the CSRF token must be appended to the WS URL as a query
         # parameter — Qlik November 2024+ rejects the upgrade with 403 if the
@@ -86,31 +93,31 @@ class QlikEngineAPI:
         jwt_csrf_qs = ""
         if is_jwt:
             if self.jwt_session is None:
-                raise ConnectionError(
+                raise QlikConnectionError(
                     "JWT mode requires a JwtSession — check server._init_clients wiring."
                 )
             try:
                 self.jwt_session.ensure_standalone()
             except JwtBootstrapError as exc:
-                raise ConnectionError(f"JWT session bootstrap failed: {exc}") from exc
+                raise QlikConnectionError(f"JWT session bootstrap failed: {exc}") from exc
             if self.jwt_session.csrf_token:
                 jwt_csrf_qs = f"?qlik-csrf-token={quote(self.jwt_session.csrf_token, safe='')}"
 
         # Build endpoint list — per-app first if app_id is given.
         endpoints_all: List[str] = []
         if is_jwt:
-            # Via virtual proxy on 443. No ws:// fallback — TLS is mandatory
-            # because the JWT was minted against a TLS-protected Host allow
-            # list in QMC.
+            # Via virtual proxy on 443 (or the configured non-standard port).
+            # No ws:// fallback — TLS is mandatory because the JWT was minted
+            # against a TLS-protected Host allow list in QMC.
             prefix = self.config.virtual_proxy_prefix
             if app_id:
                 enc = quote(app_id, safe="")
                 endpoints_all.append(
-                    f"wss://{server_host}/{prefix}/app/{enc}{jwt_csrf_qs}"
+                    f"wss://{server_netloc}/{prefix}/app/{enc}{jwt_csrf_qs}"
                 )
             endpoints_all.extend([
-                f"wss://{server_host}/{prefix}/app/engineData{jwt_csrf_qs}",
-                f"wss://{server_host}/{prefix}/app{jwt_csrf_qs}",
+                f"wss://{server_netloc}/{prefix}/app/engineData{jwt_csrf_qs}",
+                f"wss://{server_netloc}/{prefix}/app{jwt_csrf_qs}",
             ])
         else:
             if app_id:
@@ -162,9 +169,11 @@ class QlikEngineAPI:
                   if self.jwt_session.csrf_token else []),
                 # Origin must match an entry in the VP Host allow list from
                 # QMC. Qlik accepts the bare hostname entry and compares
-                # case-insensitively against the Origin hostname, so the
-                # canonical https://<hostname> form works.
-                f"Origin: https://{server_host}",
+                # case-insensitively against the Origin hostname. We reuse
+                # the scheme/netloc from the configured server_url so
+                # non-standard ports are preserved and http vs https is not
+                # hardcoded.
+                f"Origin: {server_scheme}://{server_netloc}",
             ]
         else:
             headers = [
@@ -172,7 +181,10 @@ class QlikEngineAPI:
             ]
 
         last_error = None
-        for url in endpoints_to_try:
+        jwt_retried = False  # one re-bootstrap per connect() call
+        i = 0
+        while i < len(endpoints_to_try):
+            url = endpoints_to_try[i]
             try:
                 if url.startswith("wss://"):
                     self.ws = websocket.create_connection(
@@ -186,6 +198,45 @@ class QlikEngineAPI:
                 # initial recv to establish session
                 self.ws.recv()
                 return  # Success
+            except websocket.WebSocketBadStatusException as e:
+                last_error = e
+                if self.ws:
+                    try:
+                        self.ws.close()
+                    except Exception:
+                        pass
+                    self.ws = None
+                # On a stale JWT session we see 401 (cookie expired) or 403
+                # (CSRF stale under CSWSH). Re-bootstrap once and retry the
+                # same URL — symmetric to the QRS 401-retry path. If we are
+                # not in JWT mode or we already retried, fall through to the
+                # next fallback endpoint.
+                if (is_jwt
+                        and not jwt_retried
+                        and self.jwt_session is not None
+                        and getattr(e, "status_code", None) in (401, 403)):
+                    jwt_retried = True
+                    self.jwt_session.invalidate()
+                    try:
+                        self.jwt_session.ensure_standalone()
+                    except JwtBootstrapError as boot_exc:
+                        raise QlikConnectionError(
+                            f"JWT session re-bootstrap after {e.status_code} failed: {boot_exc}"
+                        ) from boot_exc
+                    # Refresh csrf query-param, cookie header, rebuild URL list.
+                    new_csrf = self.jwt_session.csrf_token
+                    new_qs = (f"?qlik-csrf-token={quote(new_csrf, safe='')}"
+                              if new_csrf else "")
+                    endpoints_to_try = [
+                        u.split("?", 1)[0] + new_qs for u in endpoints_to_try
+                    ]
+                    headers = [
+                        f"Cookie: {self.jwt_session.cookie_header()}",
+                        *([f"qlik-csrf-token: {new_csrf}"] if new_csrf else []),
+                        f"Origin: {server_scheme}://{server_netloc}",
+                    ]
+                    continue  # retry same i
+                i += 1
             except Exception as e:
                 last_error = e
                 if self.ws:
@@ -194,9 +245,9 @@ class QlikEngineAPI:
                     except Exception:
                         pass
                     self.ws = None
-                continue
+                i += 1
 
-        raise ConnectionError(
+        raise QlikConnectionError(
             f"Failed to connect to Engine API. Last error: {str(last_error)}"
         )
 

--- a/qlik_sense_mcp_server/jwt_session.py
+++ b/qlik_sense_mcp_server/jwt_session.py
@@ -33,6 +33,7 @@ Sources:
 from __future__ import annotations
 
 import logging
+import os
 import ssl
 import threading
 import time
@@ -46,8 +47,31 @@ logger = logging.getLogger(__name__)
 
 
 # Qlik default session idle timeout is 30 minutes. We refresh a little earlier
-# so a borderline request never races the server-side eviction.
+# so a borderline request never races the server-side eviction. Can be
+# overridden by the ``QLIK_JWT_SESSION_TTL`` environment variable for
+# deployments whose QMC session timeout differs from the default 30 minutes.
 DEFAULT_JWT_SESSION_TTL_SECONDS = 25 * 60
+
+
+def _ttl_from_env(default: int = DEFAULT_JWT_SESSION_TTL_SECONDS) -> int:
+    raw = os.getenv("QLIK_JWT_SESSION_TTL")
+    if not raw:
+        return default
+    try:
+        v = int(raw)
+    except ValueError:
+        logger.warning(
+            "QLIK_JWT_SESSION_TTL=%r is not an integer, falling back to %d",
+            raw, default,
+        )
+        return default
+    if v <= 0:
+        logger.warning(
+            "QLIK_JWT_SESSION_TTL must be positive, got %d — falling back to %d",
+            v, default,
+        )
+        return default
+    return v
 
 # Names of session cookies to recognize when auto-detecting from Set-Cookie.
 # Any cookie whose name starts with "X-Qlik-Session" is treated as a session
@@ -72,10 +96,11 @@ class JwtSession:
     def __init__(
         self,
         config: QlikSenseConfig,
-        ttl_seconds: int = DEFAULT_JWT_SESSION_TTL_SECONDS,
+        ttl_seconds: Optional[int] = None,
     ) -> None:
         self._config = config
-        self._ttl = ttl_seconds
+        # Explicit arg wins over env, env wins over default.
+        self._ttl = ttl_seconds if ttl_seconds is not None else _ttl_from_env()
         self._lock = threading.Lock()
         self._cookie_name: Optional[str] = config.jwt_session_cookie_override
         self._cookie_value: Optional[str] = None
@@ -83,19 +108,25 @@ class JwtSession:
         self._fetched_at: float = 0.0
 
     # ─── public surface ────────────────────────────────────────────────
+    # Reader properties snapshot the three session fields under the lock
+    # so a concurrent ``invalidate()`` can't surface a half-updated state
+    # (e.g. cookie present but csrf already cleared).
 
     @property
     def cookie_name(self) -> Optional[str]:
         """Last known session cookie name (None until first bootstrap)."""
-        return self._cookie_name
+        with self._lock:
+            return self._cookie_name
 
     @property
     def cookie_value(self) -> Optional[str]:
-        return self._cookie_value
+        with self._lock:
+            return self._cookie_value
 
     @property
     def csrf_token(self) -> Optional[str]:
-        return self._csrf_token
+        with self._lock:
+            return self._csrf_token
 
     def cookie_header(self) -> str:
         """
@@ -104,9 +135,10 @@ class JwtSession:
         Call only after ``ensure()`` — raises if the session has not been
         bootstrapped yet.
         """
-        if not (self._cookie_name and self._cookie_value):
-            raise JwtBootstrapError("JwtSession.cookie_header() called before ensure()")
-        return f"{self._cookie_name}={self._cookie_value}"
+        with self._lock:
+            if not (self._cookie_name and self._cookie_value):
+                raise JwtBootstrapError("JwtSession.cookie_header() called before ensure()")
+            return f"{self._cookie_name}={self._cookie_value}"
 
     def invalidate(self) -> None:
         """Drop the cached session so the next ensure() refetches."""
@@ -241,7 +273,9 @@ class JwtSession:
 
         self._cookie_name = cookie_name
         self._cookie_value = cookie_value
-        self._csrf_token = csrf or ""
+        # Store "missing" as None (not ""); the public csrf_token property
+        # stays Optional[str] and downstream code uses truthiness checks.
+        self._csrf_token = csrf or None
         self._fetched_at = time.time()
         logger.info(
             "JWT session bootstrap OK (cookie=%s, csrf_present=%s)",

--- a/qlik_sense_mcp_server/jwt_session.py
+++ b/qlik_sense_mcp_server/jwt_session.py
@@ -1,0 +1,285 @@
+"""
+Bootstrap a Qlik Sense Enterprise session from a pre-signed JWT.
+
+On Qlik Sense November 2024+ (and everything later) Engine WebSocket
+connections with just ``Authorization: Bearer <jwt>`` on the upgrade request
+fail with 403 Forbidden. This is Qlik's intentional Cross-Site WebSocket
+Hijacking protection (CSWSH): the virtual proxy now requires a real session
+cookie and an anti-CSRF header that is only issued through a dedicated
+bootstrap endpoint.
+
+The supported two-phase flow, used by this module for ALL Qlik versions
+(the extra header is harmless on pre-Nov-2024 releases):
+
+    Phase 1 — GET {server}/{vp_prefix}/qps/csrftoken
+              Headers: Authorization: Bearer <jwt>
+              Response: Set-Cookie: X-Qlik-Session-<prefix>=<value>
+                        HTTP header: qlik-csrf-token: <value>
+
+    Phase 2 — Everything else (QRS HTTP requests, Engine WebSocket):
+              Use the session cookie + the csrf token. Do NOT repeat
+              the Authorization header — that is exactly what CSWSH
+              protection rejects on a WebSocket upgrade.
+
+The bootstrap result is cached for a conservative TTL (default 25 min —
+Qlik session idle timeout is 30 min, leaving a 5 min buffer) and
+transparently re-fetched when stale or on an explicit invalidate().
+
+Sources:
+    https://community.qlik.com/t5/Integration-Extension-APIs/Qlik-Sense-Nov-2025-WebSocket-connections-via-JWT-fail-with-403/td-p/2539417
+    https://help.qlik.com/en-US/sense-developer/November2025/Subsystems/EngineAPI/Content/Sense_EngineAPI/GettingStarted/connecting-to-engine-api.htm
+"""
+
+from __future__ import annotations
+
+import logging
+import ssl
+import threading
+import time
+from typing import Optional
+
+import httpx
+
+from .config import QlikSenseConfig
+
+logger = logging.getLogger(__name__)
+
+
+# Qlik default session idle timeout is 30 minutes. We refresh a little earlier
+# so a borderline request never races the server-side eviction.
+DEFAULT_JWT_SESSION_TTL_SECONDS = 25 * 60
+
+# Names of session cookies to recognize when auto-detecting from Set-Cookie.
+# Any cookie whose name starts with "X-Qlik-Session" is treated as a session
+# cookie — Qlik uses "X-Qlik-Session" on the central proxy and
+# "X-Qlik-Session-<prefix>" on virtual proxies.
+_QLIK_SESSION_COOKIE_PREFIX = "X-Qlik-Session"
+
+
+class JwtBootstrapError(RuntimeError):
+    """Raised when /qps/csrftoken bootstrap fails irrecoverably."""
+
+
+class JwtSession:
+    """
+    Lazy, thread-safe holder of the bootstrapped Qlik session material.
+
+    One instance per MCP process is sufficient because all MCP tools impersonate
+    the single analyst identity encoded in the JWT. ``repository_api`` and
+    ``engine_api`` share the same instance via ``server._init_clients``.
+    """
+
+    def __init__(
+        self,
+        config: QlikSenseConfig,
+        ttl_seconds: int = DEFAULT_JWT_SESSION_TTL_SECONDS,
+    ) -> None:
+        self._config = config
+        self._ttl = ttl_seconds
+        self._lock = threading.Lock()
+        self._cookie_name: Optional[str] = config.jwt_session_cookie_override
+        self._cookie_value: Optional[str] = None
+        self._csrf_token: Optional[str] = None
+        self._fetched_at: float = 0.0
+
+    # ─── public surface ────────────────────────────────────────────────
+
+    @property
+    def cookie_name(self) -> Optional[str]:
+        """Last known session cookie name (None until first bootstrap)."""
+        return self._cookie_name
+
+    @property
+    def cookie_value(self) -> Optional[str]:
+        return self._cookie_value
+
+    @property
+    def csrf_token(self) -> Optional[str]:
+        return self._csrf_token
+
+    def cookie_header(self) -> str:
+        """
+        Build a ``Cookie:`` HTTP header value for the current session.
+
+        Call only after ``ensure()`` — raises if the session has not been
+        bootstrapped yet.
+        """
+        if not (self._cookie_name and self._cookie_value):
+            raise JwtBootstrapError("JwtSession.cookie_header() called before ensure()")
+        return f"{self._cookie_name}={self._cookie_value}"
+
+    def invalidate(self) -> None:
+        """Drop the cached session so the next ensure() refetches."""
+        with self._lock:
+            self._cookie_value = None
+            self._csrf_token = None
+            self._fetched_at = 0.0
+            # Keep cookie_name if it was supplied via env override, reset
+            # otherwise so a fresh Set-Cookie is picked up.
+            if not self._config.jwt_session_cookie_override:
+                self._cookie_name = None
+
+    def ensure(self, http_client: httpx.Client) -> None:
+        """
+        Guarantee a valid bootstrapped session, using the given ``httpx.Client``.
+
+        Safe to call on every request — returns fast if the session is still
+        fresh (within TTL). The passed-in client keeps the cookie jar so the
+        bootstrapped session cookie is reused for subsequent QRS calls
+        automatically (httpx persists cookies per-client).
+        """
+        if self._is_fresh():
+            return
+        with self._lock:
+            if self._is_fresh():  # re-check under lock
+                return
+            self._bootstrap(http_client)
+
+    def ensure_standalone(self) -> None:
+        """
+        Bootstrap without an externally-supplied ``httpx.Client``.
+
+        Used by ``engine_api.connect()`` which does not own an httpx client —
+        we create a short-lived one just to perform phase 1. The resulting
+        cookie + csrf values are stored on this JwtSession for the WebSocket
+        handshake; we do NOT need the cookie to persist in an httpx jar here.
+        """
+        if self._is_fresh():
+            return
+        with self._lock:
+            if self._is_fresh():
+                return
+            client = self._build_bootstrap_client()
+            try:
+                self._bootstrap(client)
+            finally:
+                client.close()
+
+    # ─── internals ─────────────────────────────────────────────────────
+
+    def _is_fresh(self) -> bool:
+        if not (self._cookie_value and self._csrf_token):
+            return False
+        return (time.time() - self._fetched_at) < self._ttl
+
+    def _build_bootstrap_client(self) -> httpx.Client:
+        """Build a minimal httpx client suitable for the csrftoken call."""
+        if self._config.verify_ssl:
+            ctx = ssl.create_default_context()
+            if self._config.ca_cert_path:
+                ctx.load_verify_locations(self._config.ca_cert_path)
+            verify: object = ctx
+        else:
+            verify = False
+        return httpx.Client(verify=verify, timeout=30.0)
+
+    def _bootstrap(self, client: httpx.Client) -> None:
+        """
+        Phase 1 request. Stores cookie + csrf token on success.
+
+        Must be called with ``self._lock`` held.
+        """
+        cfg = self._config
+        if not cfg.jwt_token:
+            raise JwtBootstrapError("jwt_token is empty — cannot bootstrap")
+        if not cfg.virtual_proxy_prefix:
+            raise JwtBootstrapError(
+                "virtual_proxy_prefix is empty — set QLIK_SERVER_URL to include "
+                "the VP prefix, e.g. https://qlik.company.com/jwt"
+            )
+
+        url = f"{cfg.qlik_base_host}/{cfg.virtual_proxy_prefix}/qps/csrftoken"
+        headers = {
+            "Authorization": f"Bearer {cfg.jwt_token}",
+            "Accept": "application/json",
+        }
+        logger.info("Bootstrapping JWT session via %s", url)
+        try:
+            resp = client.get(url, headers=headers)
+        except httpx.HTTPError as exc:
+            raise JwtBootstrapError(f"csrftoken request failed: {exc}") from exc
+
+        if resp.status_code == 401:
+            raise JwtBootstrapError(
+                "csrftoken returned 401 — JWT rejected by the virtual proxy. "
+                "Check that the token has not expired, that the VP JWT "
+                "certificate matches the private key you signed with, and "
+                "that the JWT claim names match the VP 'JWT attribute for "
+                "user ID / user directory' fields."
+            )
+        if resp.status_code == 403:
+            raise JwtBootstrapError(
+                "csrftoken returned 403 — VP refused the request. Most "
+                "common cause: the client hostname is not in the VP Host "
+                "allow list in QMC. Add the exact hostname (no IP) used in "
+                "QLIK_SERVER_URL to the VP allow list and retry."
+            )
+        if resp.status_code >= 400:
+            raise JwtBootstrapError(
+                f"csrftoken returned HTTP {resp.status_code}: {resp.text[:300]}"
+            )
+
+        csrf = resp.headers.get("qlik-csrf-token")
+        if not csrf:
+            # Some older QSEoW builds return the token only as a query param
+            # redirect or in a different header casing — log and continue if
+            # we at least have a session cookie, callers will fail loudly on
+            # the WS handshake if it turns out CSWSH protection is active.
+            logger.warning(
+                "csrftoken response did not include a 'qlik-csrf-token' header. "
+                "This is fine on pre-Nov-2024 Qlik versions but will cause 403 "
+                "on newer releases."
+            )
+
+        cookie_name, cookie_value = self._pick_session_cookie(resp)
+        if not cookie_value:
+            raise JwtBootstrapError(
+                "csrftoken response did not set a Qlik session cookie. Verify "
+                "that QLIK_SERVER_URL points at the JWT virtual proxy and not "
+                "at the central proxy."
+            )
+
+        self._cookie_name = cookie_name
+        self._cookie_value = cookie_value
+        self._csrf_token = csrf or ""
+        self._fetched_at = time.time()
+        logger.info(
+            "JWT session bootstrap OK (cookie=%s, csrf_present=%s)",
+            cookie_name, bool(csrf),
+        )
+
+    def _pick_session_cookie(self, resp: httpx.Response) -> tuple[Optional[str], Optional[str]]:
+        """
+        Extract the Qlik session cookie from a bootstrap response.
+
+        Honors the env override ``QLIK_JWT_SESSION_COOKIE`` first. Otherwise
+        scans response cookies for the conventional ``X-Qlik-Session*`` name
+        and falls back to the single cookie in the response if Qlik set only
+        one.
+        """
+        override = self._config.jwt_session_cookie_override
+        if override:
+            value = resp.cookies.get(override)
+            if value:
+                return override, value
+            # Explicit override but not present → treat as misconfiguration.
+            raise JwtBootstrapError(
+                f"QLIK_JWT_SESSION_COOKIE={override!r} set but no such cookie "
+                f"in csrftoken response. Available: {list(resp.cookies.keys())}"
+            )
+
+        # Prefer any cookie whose name starts with X-Qlik-Session.
+        candidates = [
+            (name, resp.cookies.get(name))
+            for name in resp.cookies.keys()
+            if name.lower().startswith(_QLIK_SESSION_COOKIE_PREFIX.lower())
+        ]
+        if candidates:
+            return candidates[0]
+
+        # Last resort — if Qlik set exactly one cookie, use it.
+        if len(resp.cookies) == 1:
+            name = next(iter(resp.cookies.keys()))
+            return name, resp.cookies.get(name)
+
+        return None, None

--- a/qlik_sense_mcp_server/repository_api.py
+++ b/qlik_sense_mcp_server/repository_api.py
@@ -16,7 +16,7 @@ from .config import (
 )
 from .jwt_session import JwtSession, JwtBootstrapError
 from .utils import generate_xrfkey
-from .exceptions import QlikRepositoryError
+from .exceptions import QlikRepositoryError, QlikConnectionError
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +27,14 @@ class QlikRepositoryAPI:
     def __init__(self, config: QlikSenseConfig, jwt_session: Optional[JwtSession] = None):
         self.config = config
         self.jwt_session = jwt_session  # required when config.auth_mode == jwt
+
+        # In JWT mode the session holder is required up front — failing here
+        # gives a clear message instead of a confusing 401 on the first call.
+        if self.config.auth_mode == AUTH_MODE_JWT and jwt_session is None:
+            raise QlikConnectionError(
+                "JWT mode requires a JwtSession — pass jwt_session=... to "
+                "QlikRepositoryAPI(). See server._init_clients for the canonical wiring."
+            )
 
         # Setup SSL verification
         if self.config.verify_ssl:

--- a/qlik_sense_mcp_server/repository_api.py
+++ b/qlik_sense_mcp_server/repository_api.py
@@ -12,7 +12,9 @@ from .config import (
     DEFAULT_HTTP_TIMEOUT,
     DEFAULT_APPS_LIMIT,
     MAX_APPS_LIMIT,
+    AUTH_MODE_JWT,
 )
+from .jwt_session import JwtSession, JwtBootstrapError
 from .utils import generate_xrfkey
 from .exceptions import QlikRepositoryError
 
@@ -22,8 +24,9 @@ logger = logging.getLogger(__name__)
 class QlikRepositoryAPI:
     """Client for Qlik Sense Repository API using httpx."""
 
-    def __init__(self, config: QlikSenseConfig):
+    def __init__(self, config: QlikSenseConfig, jwt_session: Optional[JwtSession] = None):
         self.config = config
+        self.jwt_session = jwt_session  # required when config.auth_mode == jwt
 
         # Setup SSL verification
         if self.config.verify_ssl:
@@ -35,11 +38,6 @@ class QlikRepositoryAPI:
             ssl_context.check_hostname = False
             ssl_context.verify_mode = ssl.CERT_NONE
 
-        # Setup client certificates if provided
-        cert = None
-        if self.config.client_cert_path and self.config.client_key_path:
-            cert = (self.config.client_cert_path, self.config.client_key_path)
-
         # Timeouts from env (seconds)
         http_timeout_env = os.getenv("QLIK_HTTP_TIMEOUT")
         try:
@@ -47,20 +45,39 @@ class QlikRepositoryAPI:
         except ValueError:
             timeout_val = DEFAULT_HTTP_TIMEOUT
 
-        # Create httpx client with certificates and SSL context
+        # Build per-mode client config. JWT mode uses neither client certs
+        # nor X-Qlik-User impersonation — identity comes from the signed
+        # bearer token validated by the VP, and after the first bootstrap
+        # call the cookie jar authenticates the rest.
+        if self.config.auth_mode == AUTH_MODE_JWT:
+            cert = None
+            default_headers = {"Content-Type": "application/json"}
+        else:
+            cert = None
+            if self.config.client_cert_path and self.config.client_key_path:
+                cert = (self.config.client_cert_path, self.config.client_key_path)
+            default_headers = {
+                "X-Qlik-User": f"UserDirectory={self.config.user_directory}; UserId={self.config.user_id}",
+                "Content-Type": "application/json",
+            }
+
         self.client = httpx.Client(
             verify=ssl_context if self.config.verify_ssl else False,
             cert=cert,
             timeout=timeout_val,
-            headers={
-                "X-Qlik-User": f"UserDirectory={self.config.user_directory}; UserId={self.config.user_id}",
-                "Content-Type": "application/json",
-            },
+            headers=default_headers,
         )
 
     def _get_api_url(self, endpoint: str) -> str:
-        """Get full API URL for endpoint."""
-        base_url = f"{self.config.server_url}:{self.config.repository_port}"
+        """
+        Build full QRS URL for an endpoint.
+
+        Certificate mode:  https://host:4242/qrs/<endpoint>      (direct QRS)
+        JWT mode:          https://host/<vp_prefix>/qrs/<endpoint> (via VP, port 443)
+        """
+        if self.config.auth_mode == AUTH_MODE_JWT:
+            return f"{self.config.qlik_base_host}/{self.config.virtual_proxy_prefix}/qrs/{endpoint}"
+        base_url = f"{self.config.qlik_base_host}:{self.config.repository_port}"
         return f"{base_url}/qrs/{endpoint}"
 
     def _make_request(self, method: str, endpoint: str, **kwargs) -> Dict[str, Any]:
@@ -79,9 +96,42 @@ class QlikRepositoryAPI:
             # Add xrfkey header
             headers = kwargs.get('headers', {})
             headers['X-Qlik-Xrfkey'] = xrfkey
+
+            # JWT mode: make sure the session cookie is bootstrapped, then
+            # attach the anti-CSWSH header. Bootstrap Set-Cookie lands in
+            # self.client.cookies automatically because we pass the same
+            # client into ensure().
+            if self.config.auth_mode == AUTH_MODE_JWT and self.jwt_session is not None:
+                try:
+                    self.jwt_session.ensure(self.client)
+                except JwtBootstrapError as bootstrap_exc:
+                    logger.error("JWT bootstrap failed: %s", bootstrap_exc)
+                    return {"error": f"JWT bootstrap failed: {bootstrap_exc}"}
+                if self.jwt_session.csrf_token:
+                    headers["qlik-csrf-token"] = self.jwt_session.csrf_token
+
             kwargs['headers'] = headers
 
             response = self.client.request(method, url, **kwargs)
+
+            # If the session cookie expired mid-flight, invalidate and retry
+            # once — this is cheaper than a proactive per-request check and
+            # covers the case where the server killed the session early.
+            if (response.status_code == 401
+                    and self.config.auth_mode == AUTH_MODE_JWT
+                    and self.jwt_session is not None):
+                logger.info("QRS returned 401, refreshing JWT session and retrying once")
+                self.jwt_session.invalidate()
+                self.client.cookies.clear()
+                try:
+                    self.jwt_session.ensure(self.client)
+                except JwtBootstrapError as bootstrap_exc:
+                    logger.error("JWT re-bootstrap after 401 failed: %s", bootstrap_exc)
+                    return {"error": f"JWT re-bootstrap failed: {bootstrap_exc}"}
+                if self.jwt_session.csrf_token:
+                    headers["qlik-csrf-token"] = self.jwt_session.csrf_token
+                response = self.client.request(method, url, **kwargs)
+
             response.raise_for_status()
 
             if response.headers.get("content-type", "").startswith("application/json"):

--- a/qlik_sense_mcp_server/server.py
+++ b/qlik_sense_mcp_server/server.py
@@ -30,9 +30,11 @@ from .config import (
     DEFAULT_FIELD_FETCH_SIZE,
     MAX_FIELD_FETCH_SIZE,
     DEFAULT_TICKET_TIMEOUT,
+    AUTH_MODE_JWT,
 )
 from .repository_api import QlikRepositoryAPI
 from .engine_api import QlikEngineAPI
+from .jwt_session import JwtSession
 from .utils import generate_xrfkey
 from . import __version__
 
@@ -61,17 +63,31 @@ logger = logging.getLogger(__name__)
 config: Optional[QlikSenseConfig] = None
 repo_api: Optional[QlikRepositoryAPI] = None
 engine_api: Optional[QlikEngineAPI] = None
+jwt_session: Optional[JwtSession] = None
 
 
 def _init_clients():
-    global config, repo_api, engine_api
+    global config, repo_api, engine_api, jwt_session
     try:
         config = QlikSenseConfig.from_env()
-        if not (config.server_url and config.user_directory and config.user_id):
-            raise ValueError("Missing required config")
-        repo_api = QlikRepositoryAPI(config)
-        engine_api = QlikEngineAPI(config)
-        logger.info("Qlik Sense API clients initialised")
+        config.validate_runtime()
+
+        if config.auth_mode == AUTH_MODE_JWT:
+            jwt_session = JwtSession(config)
+            repo_api = QlikRepositoryAPI(config, jwt_session=jwt_session)
+            engine_api = QlikEngineAPI(config, jwt_session=jwt_session)
+            logger.info(
+                "Qlik Sense API clients initialised (JWT mode via virtual proxy '/%s')",
+                config.virtual_proxy_prefix,
+            )
+        else:
+            jwt_session = None
+            repo_api = QlikRepositoryAPI(config)
+            engine_api = QlikEngineAPI(config)
+            logger.info(
+                "Qlik Sense API clients initialised (certificate mode, user=%s\\%s)",
+                config.user_directory, config.user_id,
+            )
     except Exception as e:
         logger.warning("Failed to init Qlik API clients: %s", e)
 

--- a/tools/qlik_jwt_admin.py
+++ b/tools/qlik_jwt_admin.py
@@ -203,6 +203,33 @@ def cmd_issue_token(args: argparse.Namespace) -> int:
         # Machine-readable: just the token on stdout, nothing else.
         print(token)
     else:
+        # Warn when printed to an interactive terminal — the token ends up in
+        # the shell scrollback / tmux buffer / terminal logs and should be
+        # treated as a password.
+        if sys.stdout.isatty():
+            sys.stderr.write(
+                "NOTE: the token below is a bearer credential. Your terminal "
+                "is interactive, so the value will be written to shell "
+                "scrollback and any terminal log. Copy it to the analyst via "
+                "a secure channel and clear the scrollback afterwards.\n\n"
+            )
+
+        # Also warn if the admin deviates from the defaults we document — a
+        # silent mismatch with the QMC VP config is the #1 reason tokens are
+        # rejected. This does not prevent the token from being issued.
+        if args.user_id_claim != "userId":
+            sys.stderr.write(
+                f"WARNING: --user-id-claim={args.user_id_claim!r} differs from "
+                f"the documented default 'userId'. Make sure 'JWT attribute for "
+                f"user ID' in QMC matches exactly.\n"
+            )
+        if args.user_dir_claim != "userDirectory":
+            sys.stderr.write(
+                f"WARNING: --user-dir-claim={args.user_dir_claim!r} differs from "
+                f"the documented default 'userDirectory'. Make sure 'JWT attribute "
+                f"for user directory' in QMC matches exactly.\n"
+            )
+
         print()
         print("=" * 72)
         print(f"  JWT for {args.user_directory}\\{args.user_id}")
@@ -260,9 +287,11 @@ def _build_parser() -> argparse.ArgumentParser:
                          help="Qlik userId (e.g. the AD sAMAccountName, 'ivanov')")
     p_issue.add_argument("--user-directory", required=True,
                          help="Qlik userDirectory (e.g. AD domain, 'COMPANY')")
-    p_issue.add_argument("--days", type=int, default=365,
-                         help="Token lifetime in days (default 365). Use a larger value "
-                              "for long-lived service tokens, a smaller one for tighter rotation.")
+    p_issue.add_argument("--days", type=int, default=90,
+                         help="Token lifetime in days (default 90). Bearer JWTs cannot be "
+                              "individually revoked, so prefer the shortest lifetime that is "
+                              "operationally acceptable. Use a larger value (e.g. 365) for "
+                              "service tokens, a smaller one for tighter rotation.")
     p_issue.add_argument("--user-id-claim", default="userId",
                          help="JWT claim name holding user ID — must match 'JWT attribute "
                               "for user ID' in QMC (default userId)")

--- a/tools/qlik_jwt_admin.py
+++ b/tools/qlik_jwt_admin.py
@@ -1,0 +1,292 @@
+"""
+Admin CLI for qlik-sense-mcp JWT authentication.
+
+Two subcommands:
+
+    init-keys    Generate an RSA keypair and self-signed X.509 certificate
+                 used by a Qlik Sense Enterprise JWT virtual proxy.
+
+    issue-token  Sign a long-lived JWT for a single analyst, ready to paste
+                 into their mcp.json as QLIK_JWT_TOKEN.
+
+Typical workflow for the admin (run ONCE on a machine only the admin controls):
+
+    # 1. Generate signing keys. Keep jwt_private.pem safe forever.
+    python tools/qlik_jwt_admin.py init-keys --out ./jwt_keys
+
+    # 2. Open Qlik QMC -> Configure system -> Virtual proxies -> Create new,
+    #    paste ./jwt_keys/jwt_cert.pem into the "JWT certificate" field,
+    #    set "JWT attribute for user ID" = userId,
+    #    set "JWT attribute for user directory" = userDirectory,
+    #    finish the rest of the VP wizard (prefix, session cookie, host allow list,
+    #    link to Central proxy). See docs/AUTH_JWT.md for the exact values.
+
+    # 3. For each analyst, issue a token signed with their domain identity.
+    python tools/qlik_jwt_admin.py issue-token \
+        --key ./jwt_keys/jwt_private.pem \
+        --user-id ivanov \
+        --user-directory COMPANY
+
+    # 4. Give the analyst the printed token + the Qlik URL + the virtual
+    #    proxy prefix. They put two env vars in their Cursor mcp.json and
+    #    the MCP server works.
+
+The private key NEVER leaves the admin's machine. Analysts only ever receive
+a signed JWT string — they cannot forge tokens for other users.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import os
+import stat
+import sys
+from pathlib import Path
+from typing import Optional
+
+try:
+    import jwt  # PyJWT
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+except ImportError as exc:
+    sys.stderr.write(
+        f"Missing dependency: {exc.name}\n"
+        "Install with: pip install 'PyJWT[crypto]>=2.8' 'cryptography>=41'\n"
+        "Or install the MCP package itself: pip install qlik-sense-mcp-server\n"
+    )
+    raise SystemExit(2)
+
+
+# ─── init-keys ──────────────────────────────────────────────────────────────
+
+
+def _generate_rsa_key(bits: int) -> rsa.RSAPrivateKey:
+    if bits < 2048:
+        raise ValueError("RSA keys shorter than 2048 bits are not acceptable for JWT signing")
+    return rsa.generate_private_key(public_exponent=65537, key_size=bits)
+
+
+def _build_self_signed_cert(
+    private_key: rsa.RSAPrivateKey,
+    common_name: str,
+    days_valid: int,
+) -> x509.Certificate:
+    subject = issuer = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+        x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, "qlik-sense-mcp"),
+    ])
+    now = dt.datetime.now(dt.timezone.utc)
+    return (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(private_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - dt.timedelta(minutes=5))
+        .not_valid_after(now + dt.timedelta(days=days_valid))
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .sign(private_key=private_key, algorithm=hashes.SHA256())
+    )
+
+
+def _write_secret(path: Path, data: bytes) -> None:
+    if path.exists():
+        raise FileExistsError(
+            f"{path} already exists — delete it manually to avoid overwriting a key by accident"
+        )
+    path.write_bytes(data)
+    try:
+        # 0600 on *nix; no-op on Windows NTFS, but does not hurt.
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+    except OSError:
+        pass
+
+
+def cmd_init_keys(args: argparse.Namespace) -> int:
+    out_dir = Path(args.out).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    private_path = out_dir / "jwt_private.pem"
+    public_path = out_dir / "jwt_public.pem"
+    cert_path = out_dir / "jwt_cert.pem"
+
+    for p in (private_path, public_path, cert_path):
+        if p.exists():
+            sys.stderr.write(f"ERROR: {p} already exists. Delete old keys manually first.\n")
+            return 1
+
+    print(f"[1/3] Generating RSA-{args.bits} private key...")
+    key = _generate_rsa_key(args.bits)
+
+    print(f"[2/3] Building self-signed certificate CN={args.cn}, valid {args.cert_days} days...")
+    cert = _build_self_signed_cert(key, common_name=args.cn, days_valid=args.cert_days)
+
+    print(f"[3/3] Writing files to {out_dir}")
+    _write_secret(
+        private_path,
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ),
+    )
+    public_path.write_bytes(
+        key.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    )
+    cert_path.write_bytes(cert.public_bytes(encoding=serialization.Encoding.PEM))
+
+    print()
+    print("Done. Files created:")
+    print(f"  PRIVATE  {private_path}   <-- secret, keep ONLY on the admin machine")
+    print(f"  PUBLIC   {public_path}    (informational)")
+    print(f"  CERT     {cert_path}      <-- paste into QMC JWT virtual proxy 'JWT certificate' field")
+    print()
+    print("Next: see docs/AUTH_JWT.md for the QMC virtual proxy setup.")
+    return 0
+
+
+# ─── issue-token ────────────────────────────────────────────────────────────
+
+
+def _load_private_key(path: Path) -> rsa.RSAPrivateKey:
+    data = path.read_bytes()
+    key = serialization.load_pem_private_key(data, password=None)
+    if not isinstance(key, rsa.RSAPrivateKey):
+        raise ValueError(f"{path} does not contain an RSA private key")
+    return key
+
+
+def cmd_issue_token(args: argparse.Namespace) -> int:
+    key_path = Path(args.key).resolve()
+    if not key_path.is_file():
+        sys.stderr.write(f"ERROR: private key not found: {key_path}\n")
+        return 1
+
+    try:
+        private_key = _load_private_key(key_path)
+    except Exception as exc:
+        sys.stderr.write(f"ERROR: failed to load private key: {exc}\n")
+        return 1
+
+    if args.days <= 0:
+        sys.stderr.write("ERROR: --days must be positive\n")
+        return 1
+
+    now = dt.datetime.now(dt.timezone.utc)
+    # Small backdate so minor clock skew between the admin machine and the
+    # Qlik server does not reject a freshly-issued token.
+    iat = now - dt.timedelta(seconds=30)
+    exp = now + dt.timedelta(days=args.days)
+
+    payload: dict = {
+        args.user_id_claim: args.user_id,
+        args.user_dir_claim: args.user_directory,
+        "iat": int(iat.timestamp()),
+        "exp": int(exp.timestamp()),
+    }
+    if args.issuer:
+        payload["iss"] = args.issuer
+    if args.audience:
+        payload["aud"] = args.audience
+    if args.jti:
+        payload["jti"] = args.jti
+
+    token = jwt.encode(payload, private_key, algorithm="RS256")
+
+    if args.quiet:
+        # Machine-readable: just the token on stdout, nothing else.
+        print(token)
+    else:
+        print()
+        print("=" * 72)
+        print(f"  JWT for {args.user_directory}\\{args.user_id}")
+        print(f"  Valid until: {exp.isoformat()}")
+        print("=" * 72)
+        print()
+        print(token)
+        print()
+        print("Analyst mcp.json env block:")
+        print()
+        print('  "env": {')
+        print('    "QLIK_SERVER_URL": "https://<your-qlik-host>/<prefix>",')
+        print(f'    "QLIK_JWT_TOKEN": "{token}"')
+        print('  }')
+        print()
+        print("Replace <your-qlik-host> and <prefix> with the actual Qlik")
+        print("hostname and the prefix of the JWT virtual proxy you configured")
+        print("in QMC (the recommended prefix is 'jwt').")
+    return 0
+
+
+# ─── argument parser ────────────────────────────────────────────────────────
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="qlik_jwt_admin",
+        description="Admin CLI for qlik-sense-mcp JWT authentication (keys + tokens).",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # init-keys
+    p_init = sub.add_parser(
+        "init-keys",
+        help="Generate RSA keypair + self-signed certificate for the JWT virtual proxy.",
+    )
+    p_init.add_argument("--out", default="./jwt_keys",
+                        help="Output directory (default: ./jwt_keys)")
+    p_init.add_argument("--bits", type=int, default=2048,
+                        help="RSA key size in bits (2048 or 4096, default 2048)")
+    p_init.add_argument("--cert-days", type=int, default=3650,
+                        help="Self-signed certificate validity in days (default 3650 / 10 years)")
+    p_init.add_argument("--cn", default="qlik-mcp-jwt",
+                        help="CommonName for the self-signed certificate (default qlik-mcp-jwt)")
+    p_init.set_defaults(func=cmd_init_keys)
+
+    # issue-token
+    p_issue = sub.add_parser(
+        "issue-token",
+        help="Sign a JWT for a single analyst (one token = one Qlik identity).",
+    )
+    p_issue.add_argument("--key", required=True,
+                         help="Path to jwt_private.pem produced by init-keys")
+    p_issue.add_argument("--user-id", required=True,
+                         help="Qlik userId (e.g. the AD sAMAccountName, 'ivanov')")
+    p_issue.add_argument("--user-directory", required=True,
+                         help="Qlik userDirectory (e.g. AD domain, 'COMPANY')")
+    p_issue.add_argument("--days", type=int, default=365,
+                         help="Token lifetime in days (default 365). Use a larger value "
+                              "for long-lived service tokens, a smaller one for tighter rotation.")
+    p_issue.add_argument("--user-id-claim", default="userId",
+                         help="JWT claim name holding user ID — must match 'JWT attribute "
+                              "for user ID' in QMC (default userId)")
+    p_issue.add_argument("--user-dir-claim", default="userDirectory",
+                         help="JWT claim name holding user directory — must match 'JWT "
+                              "attribute for user directory' in QMC (default userDirectory)")
+    p_issue.add_argument("--issuer", default=None,
+                         help="Optional iss claim")
+    p_issue.add_argument("--audience", default=None,
+                         help="Optional aud claim")
+    p_issue.add_argument("--jti", default=None,
+                         help="Optional jti claim (opaque unique token id for audit trails)")
+    p_issue.add_argument("--quiet", action="store_true",
+                         help="Print only the token on stdout (for scripting)")
+    p_issue.set_defaults(func=cmd_issue_token)
+
+    return parser
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a second auth mode to the MCP server where analysts use a long-lived JWT signed by an admin. Certificate mode is unchanged; JWT mode is selected automatically when `QLIK_JWT_TOKEN` is set.

- New module `qlik_sense_mcp_server/jwt_session.py` — lazy, thread-safe holder of the bootstrapped Qlik session (session cookie + `qlik-csrf-token`), with a 25-min TTL and automatic refresh on 401 / session invalidation.
- Admin CLI `tools/qlik_jwt_admin.py` with `init-keys` (RSA 2048 keypair + self-signed X.509 for the JWT virtual proxy) and `issue-token` (sign a long-lived RS256 JWT per analyst).
- QRS HTTP client (`repository_api.py`) and Engine WebSocket client (`engine_api.py`) now route through the JWT virtual proxy on 443 instead of 4242/4747 when a JWT is configured.
- **WebSocket CSRF fix for Qlik November 2024+:** the anti-CSWSH `qlik-csrf-token` must be passed as a URL query parameter, not just an HTTP header. `engine_api.connect()` now appends `?qlik-csrf-token=<value>` to the WSS URL after the JWT session bootstrap. Sending it only in a header still returns 403.
- Docs `docs/AUTH_JWT.md` — full admin/analyst setup, QMC virtual proxy values, troubleshooting. Captures one non-obvious multi-node requirement: a prefixed virtual proxy must be linked to the Central Proxy, not only the node-specific proxy that serves the public hostname, or all prefixed paths return HTTP 400 "The http request header is incorrect".
- `.gitignore`: `users/` (per-analyst token packs), `jwt_keys/` (admin signing keys), `.playwright-mcp/` — never commit.

## Test plan

Validated end-to-end against a live multi-node Qlik Sense cluster (build 31.56.2.0, November 2025 family):

- [x] `init-keys` generates RSA keypair + cert; cert pastes into QMC JWT VP.
- [x] `issue-token` produces an RS256 JWT with the expected claims.
- [x] JWT bootstrap on `/qps/csrftoken` returns 204 + session cookie + csrf header.
- [x] QRS HTTP via `/qrs/about`, `/qrs/stream/full`, `/qrs/app/full` through the VP — 200 across the board.
- [x] Engine WebSocket global `GetDocList` — returns the list of apps the user is entitled to see (1840 docs under an admin stub, 1 doc under a restricted `MCP\analysis1` stub with `MCP_access=1` security rule).
- [x] Per-app connect `wss://<host>/<prefix>/app/<app-id>?qlik-csrf-token=<value>` — WS handshake 101 Switching Protocols.
- [x] Custom-property-based access scheme verified: `MCP\analysis1` with `MCP_access=1` sees exactly the apps where the same CP is set, via both QRS and Engine.