### PR TITLE
Release v1.5.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.1
+current_version = 1.5.1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.5.1] - 2026-04-27
+
+### Changed
+- **Documentation overhaul.** All `.md` files reviewed for accuracy
+  against the v1.5.0 source: README highlights renamed to v1.5.0
+  with a JWT auth bullet, JWT row added to the documentation index,
+  `docs/configuration.md` gained a complete JWT environment-variable
+  reference (`QLIK_JWT_TOKEN`, `QLIK_JWT_USER_ID_CLAIM`,
+  `QLIK_JWT_USER_DIR_CLAIM`, `QLIK_JWT_SESSION_COOKIE`,
+  `QLIK_JWT_SESSION_TTL`), `docs/installation.md` gained a cert/JWT
+  branching note, `docs/architecture.md` documents the new
+  `JwtSession` component and `tools/qlik_jwt_admin.py` admin CLI,
+  `docs/troubleshooting.md` gained a JWT-authentication problems
+  section that cross-links into `docs/AUTH_JWT.md`, and
+  `docs/AUTH_JWT.md` gained a `Related` index. `COMMANDS.md` was
+  reduced to a true one-page cheatsheet pointing at the deeper
+  docs in `docs/`.
+
+### Fixed
+- **Release hygiene.** `qlik_sense_mcp_server/__init__.py` and
+  `.bumpversion.cfg` were not bumped during the 1.5.0 release and
+  still reported `1.4.1`. Both are brought back in sync with
+  `pyproject.toml` as part of this release.
+
 ## [1.5.0] - 2026-04-24
 
 ### Added

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,46 +1,79 @@
 # Quick Commands Reference
 
-## Installation and Usage
+Quick reference. For full documentation see `docs/`:
+`installation.md` (install + certs) · `configuration.md` (env vars) · `usage.md` (MCP client setup) · `tools.md` (tool catalog) · `development.md` (dev + tests) · `architecture.md` · `troubleshooting.md` · `AUTH_JWT.md` (JWT mode).
+
+## Run
 
 ```bash
-# Install and run with uvx (recommended)
+# One-shot via uvx (no global install)
 uvx qlik-sense-mcp-server
-
-# Install from PyPI
-pip install qlik-sense-mcp-server
 
 # Run installed package
 qlik-sense-mcp-server
 ```
 
-## Development
+## Install
 
 ```bash
-# Setup development environment
+# From PyPI
+pip install qlik-sense-mcp-server
+
+# Or use uv
+uv tool install qlik-sense-mcp-server
+```
+
+See `docs/installation.md` for client-certificate export and `docs/configuration.md` for env vars.
+
+## Develop
+
+```bash
+# Bootstrap venv + dev deps
 make dev
 
-# See all available commands
+# All available targets
 make help
 
-# Build package
+# Build sdist + wheel
 make build
 ```
 
-## Version Management
+See `docs/development.md` for tests, lint, and contribution flow.
+
+## Release
 
 ```bash
-# Bump version and create PR
-make version-patch  # 1.0.0 -> 1.0.1
-make version-minor  # 1.0.0 -> 1.1.0
-make version-major  # 1.0.0 -> 2.0.0
+# Bump version, open PR (current line: 1.5.0)
+make version-patch  # 1.5.0 -> 1.5.1
+make version-minor  # 1.5.0 -> 1.6.0
+make version-major  # 1.5.0 -> 2.0.0
+
+# After PR merge: tag and push — GitHub Actions publishes to PyPI
+git tag v1.5.1
+git push origin v1.5.1
 ```
 
-## Publishing
+## JWT (admin)
 
 ```bash
-# After merging PR with version bump
-git tag v1.0.1
-git push origin v1.0.1
+# 1. Generate signing key + self-signed cert (run once, admin machine only)
+python tools/qlik_jwt_admin.py init-keys --out ./jwt_keys
 
-# GitHub Actions will automatically publish to PyPI
+# 2. Issue a per-analyst token (defaults: --days 90, RS256, claims userId/userDirectory)
+python tools/qlik_jwt_admin.py issue-token \
+    --key ./jwt_keys/jwt_private.pem \
+    --user-id ivanov \
+    --user-directory COMPANY \
+    --days 90
+
+# Long-lived service token
+python tools/qlik_jwt_admin.py issue-token \
+    --key ./jwt_keys/jwt_private.pem \
+    --user-id svc_ai --user-directory COMPANY --days 365
+
+# Scripting (token-only on stdout)
+python tools/qlik_jwt_admin.py issue-token --key ./jwt_keys/jwt_private.pem \
+    --user-id ivanov --user-directory COMPANY --quiet
 ```
+
+Paste `./jwt_keys/jwt_cert.pem` into the QMC JWT virtual proxy. Full setup, QMC fields, and troubleshooting: see `docs/AUTH_JWT.md`.

--- a/README.md
+++ b/README.md
@@ -33,12 +33,17 @@ variables — see [`docs/configuration.md`](docs/configuration.md).
 
 For stdio mode (legacy MCP transport), pass `--stdio`.
 
+Two authentication modes are supported: client certificate (legacy,
+full QRS access) and JWT via virtual proxy (per-analyst, no on-disk
+secrets). See [`docs/AUTH_JWT.md`](docs/AUTH_JWT.md) for the JWT setup.
+
 ## Documentation
 
 | Document | What's inside |
 |----------|---------------|
 | [`docs/installation.md`](docs/installation.md) | Requirements, install via `uvx` / `pip` / source, certificate setup |
 | [`docs/configuration.md`](docs/configuration.md) | All `QLIK_*` environment variables, sample `.env`, MCP client config snippet |
+| [`docs/AUTH_JWT.md`](docs/AUTH_JWT.md) | JWT authentication via virtual proxy: key generation, virtual proxy setup, `QLIK_JWT_TOKEN` usage |
 | [`docs/usage.md`](docs/usage.md) | Transports, server start commands, recommended call order, hard limits enforced by this server |
 | [`docs/tools.md`](docs/tools.md) | Inventory of all 24 tools, response/error envelope, error categories |
 | [`docs/architecture.md`](docs/architecture.md) | Project layout, components, connection caching, strict id-matching, two-tier timeout |
@@ -46,8 +51,14 @@ For stdio mode (legacy MCP transport), pass `--stdio`.
 | [`docs/troubleshooting.md`](docs/troubleshooting.md) | Common errors, hypercube planning failures, verbose logging, configuration self-test |
 | [`CHANGELOG.md`](CHANGELOG.md) | Release notes |
 
-## Key facts about the v1.4.0 line
+## Key facts about the v1.5.0 line
 
+- **JWT authentication via virtual proxy.** Set `QLIK_JWT_TOKEN`
+  instead of certificate paths and the server will authenticate every
+  Repository and Engine call as the analyst encoded in the token. No
+  certificates or private keys live on the host. The legacy
+  certificate mode is unchanged and still required for full QRS access.
+  Setup guide: [`docs/AUTH_JWT.md`](docs/AUTH_JWT.md).
 - **Cached Engine WebSocket connections.** Once an app is opened, every
   subsequent tool call against the same `app_id` reuses the same
   WebSocket and the same open document. Switching `app_id` closes the

--- a/docs/AUTH_JWT.md
+++ b/docs/AUTH_JWT.md
@@ -285,3 +285,16 @@ each subsequent call.
   toward availability over rotation discipline. Pick what matches your
   policy; the default of 90 is deliberately short because bearer tokens
   have no individual revocation path.
+
+---
+
+## Related
+
+- [`docs/installation.md`](installation.md) — general install paths
+  (`uvx`, `pip`, source).
+- [`docs/configuration.md`](configuration.md) — full environment
+  variable index, including the JWT variables documented above.
+- [`docs/troubleshooting.md`](troubleshooting.md) — general
+  troubleshooting; the **JWT authentication problems** section there
+  cross-links back to the deep-dive entries on this page.
+- [`README.md`](../README.md) — project overview and quick start.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,10 @@ qlik-sense-mcp/
 │   ├── config.py         # QlikSenseConfig + defaults
 │   ├── repository_api.py # Repository (HTTP/QRS) client
 │   ├── engine_api.py     # Engine API (WebSocket) client
+│   ├── jwt_session.py    # JWT session bootstrap + cache (since v1.5.0)
 │   └── utils.py          # XSRF key generation, helpers
+├── tools/
+│   └── qlik_jwt_admin.py # Admin CLI: RSA keypair + JWT issuance (since v1.5.0)
 ├── docs/                 # All documentation (this folder)
 ├── tests/                # pytest suite
 ├── .env.example          # Configuration template
@@ -28,16 +31,33 @@ and exposes the resulting connection settings. Default ports match the
 standard
 [Qlik Sense Enterprise port allocation](https://help.qlik.com/en-US/sense-admin/Subsystems/DeployAdministerQSE/Content/Sense_DeployAdminister/QSEoW/Deploy_QSEoW/Ports.htm).
 
+### `JwtSession` ([jwt_session.py](../qlik_sense_mcp_server/jwt_session.py))
+
+Lazy, thread-safe holder of the bootstrapped Qlik session material for
+JWT mode. On first use it calls `GET /{vp_prefix}/qps/csrftoken` with
+`Authorization: Bearer <jwt>`, captures the resulting `X-Qlik-Session*`
+cookie and `qlik-csrf-token` header, and caches them for 25 minutes
+(below the 30-minute Qlik idle timeout). On a 401 / 403 from a later
+QRS or Engine call, both API clients invalidate the cache and trigger a
+transparent re-bootstrap. See [AUTH_JWT.md](AUTH_JWT.md) for the
+protocol-level details and the CSWSH rationale.
+
 ### `QlikRepositoryAPI` ([repository_api.py](../qlik_sense_mcp_server/repository_api.py))
 
 HTTP client for the Repository (QRS) API. Implements certificate auth,
 dynamic XSRF key generation, and the metadata, app, task and schedule
-endpoints used by the Repository / task tools.
+endpoints used by the Repository / task tools. Accepts an optional
+`JwtSession` — when present, it injects the bootstrapped session cookie
+plus `qlik-csrf-token` header on every request instead of presenting a
+client certificate.
 
 ### `QlikEngineAPI` ([engine_api.py](../qlik_sense_mcp_server/engine_api.py))
 
 WebSocket client for the Engine API. Speaks JSON-RPC 2.0. Hosts every
-data-side tool: hypercubes, fields, sheets, objects, script.
+data-side tool: hypercubes, fields, sheets, objects, script. Accepts
+the same optional `JwtSession`; in JWT mode the WebSocket handshake
+sends the cookie + csrf header (no `Authorization: Bearer` on the
+upgrade — that triggers Qlik's CSWSH rejection on Nov-2024+ servers).
 
 The two non-obvious parts:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,13 +7,21 @@ server, or pass them via your MCP client's `env` block.
 
 ## Required variables
 
+Note: `QLIK_USER_DIRECTORY` and `QLIK_USER_ID` are NOT used in JWT mode —
+the user identity travels in the JWT payload. See
+[JWT authentication](#jwt-authentication) below.
+
 | Variable | Description |
 |----------|-------------|
-| `QLIK_SERVER_URL` | Qlik Sense server URL, including scheme. Example: `https://qlik.company.com` |
-| `QLIK_USER_DIRECTORY` | User directory used for authentication (e.g. `COMPANY`) |
-| `QLIK_USER_ID` | User ID used for authentication |
+| `QLIK_SERVER_URL` | Qlik Sense server URL, including scheme. Example: `https://qlik.company.com`. In JWT mode include the virtual proxy prefix as URL path, e.g. `https://qlik.company.com/jwt`. |
+| `QLIK_USER_DIRECTORY` | User directory used for authentication (e.g. `COMPANY`). Cert mode only. |
+| `QLIK_USER_ID` | User ID used for authentication. Cert mode only. |
 
 ## Certificate configuration
+
+This section applies to **cert mode only**. For the JWT alternative see
+[JWT authentication](#jwt-authentication) below and
+[AUTH_JWT.md](AUTH_JWT.md) for the full QMC virtual proxy setup.
 
 Required for production. If `QLIK_CA_CERT_PATH` is not set, SSL
 verification is disabled automatically.
@@ -23,6 +31,27 @@ verification is disabled automatically.
 | `QLIK_CLIENT_CERT_PATH` | Absolute path to the client certificate file (`.pem`) |
 | `QLIK_CLIENT_KEY_PATH` | Absolute path to the client private key file (`.pem`) |
 | `QLIK_CA_CERT_PATH` | Absolute path to the CA certificate file (`.pem`) |
+
+## JWT authentication
+
+JWT mode is selected automatically when `QLIK_JWT_TOKEN` is set. In this
+mode the MCP talks to a Qlik **JWT virtual proxy** over standard HTTPS/WSS
+(port 443) — no client certificates needed on the analyst's machine. See
+[AUTH_JWT.md](AUTH_JWT.md) for the full setup, including admin-side QMC
+virtual proxy configuration and key/token issuance.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `QLIK_JWT_TOKEN` | unset | Signed JWT bearer token. Setting this switches the server to JWT mode. |
+| `QLIK_JWT_USER_ID_CLAIM` | `userId` | Name of the JWT payload claim holding the user ID. Must match the QMC virtual proxy's "JWT attribute for user ID". |
+| `QLIK_JWT_USER_DIR_CLAIM` | `userDirectory` | Name of the JWT payload claim holding the user directory. Must match the QMC virtual proxy's "JWT attribute for user directory". |
+| `QLIK_JWT_SESSION_COOKIE` | auto-detected | Override for the virtual proxy session cookie name. By default the MCP picks it up from the bootstrap response `Set-Cookie` header. |
+| `QLIK_JWT_SESSION_TTL` | `1500` | Seconds to cache the bootstrapped session before re-fetching. Lower this if the QMC Proxy "Session inactivity timeout" is below 30 minutes. |
+
+In JWT mode `QLIK_SERVER_URL` MUST include the virtual proxy prefix as
+URL path (e.g. `https://qlik.company.com/jwt`). `QLIK_USER_DIRECTORY`
+and `QLIK_USER_ID` are ignored — Qlik extracts the identity from the
+JWT payload itself.
 
 ## Network configuration
 
@@ -62,9 +91,11 @@ See [`.env.example`](../.env.example) at the repository root for a copy-pasteabl
 
 ## MCP client configuration
 
-The block below is a complete example of registering the server in an
-MCP client config. The example uses Streamable HTTP (the default), so the
+The blocks below are complete examples of registering the server in an
+MCP client config. The examples use Streamable HTTP (the default), so the
 client connects to the long-lived server process you start manually.
+
+### Cert mode
 
 ```jsonc
 {
@@ -94,3 +125,24 @@ client connects to the long-lived server process you start manually.
 ```
 
 A copy is also kept in [`mcp.json.example`](../mcp.json.example).
+
+### JWT mode
+
+Minimal config — two variables are enough. See
+[AUTH_JWT.md](AUTH_JWT.md) for the full version including optional
+overrides.
+
+```jsonc
+{
+  "mcpServers": {
+    "qlik-sense": {
+      "command": "uvx",
+      "args": ["qlik-sense-mcp-server"],
+      "env": {
+        "QLIK_SERVER_URL": "https://qlik.company.com/jwt",
+        "QLIK_JWT_TOKEN": "eyJhbGciOiJSUzI1NiJ9...."
+      }
+    }
+  }
+}
+```

--- a/docs/development.md
+++ b/docs/development.md
@@ -35,9 +35,9 @@ through `make` targets. Each target bumps the version, commits the
 change and opens a pull request:
 
 ```bash
-make version-patch    # 1.4.0 -> 1.4.1
-make version-minor    # 1.4.0 -> 1.5.0
-make version-major    # 1.4.0 -> 2.0.0
+make version-patch    # 1.5.0 -> 1.5.1
+make version-minor    # 1.5.0 -> 1.6.0
+make version-major    # 1.5.0 -> 2.0.0
 ```
 
 The PyPI package version is read from `pyproject.toml`.
@@ -78,6 +78,22 @@ The PyPI package version is read from `pyproject.toml`.
      structured error envelope.
 4. Update [`docs/tools.md`](tools.md).
 5. Update [`CHANGELOG.md`](../CHANGELOG.md).
+
+New tools normally do not need any JWT-aware code: cert vs JWT auth is
+abstracted inside `QlikRepositoryAPI` / `QlikEngineAPI`, and the
+session bootstrap + cache lives in
+[`jwt_session.py`](../qlik_sense_mcp_server/jwt_session.py). Touch
+those modules only when you change the auth protocol itself.
+
+## Admin tooling
+
+[`tools/qlik_jwt_admin.py`](../tools/qlik_jwt_admin.py) is a standalone
+admin CLI for JWT mode. It generates the RSA keypair + self-signed
+X.509 certificate the Qlik QMC virtual proxy expects (`init-keys`) and
+issues per-analyst JWTs signed with that key (`issue-token`). It does
+not depend on the running MCP server. See
+[`docs/AUTH_JWT.md`](AUTH_JWT.md) for the full setup walkthrough,
+including the QMC fields and the security model.
 
 ## Release checklist
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,7 +23,7 @@ uvx qlik-sense-mcp-server
 To pin a specific version:
 
 ```bash
-uvx qlik-sense-mcp-server@1.4.0
+uvx qlik-sense-mcp-server@1.5.0
 ```
 
 ## Install from PyPI via pip
@@ -46,6 +46,11 @@ in editable mode together with the optional `dev` extras
 (`build`, `twine`, `bump2version`, `pytest`, `pytest-asyncio`).
 
 ## Setup
+
+Two auth modes are supported. Cert mode (covered below) gives full QRS
+access and is required for admins. JWT mode is recommended for individual
+analysts — see [AUTH_JWT.md](AUTH_JWT.md) for the full setup, then come
+back here only for the install command (Step 1 above).
 
 1. Place certificates somewhere outside the repository:
    ```

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -95,3 +95,7 @@ The categories you can see from `engine_create_hypercube`:
 - `engine_api_error` — invalid expression / unknown field. The full
   Engine error is in `error`.
 - `connection_error` — WebSocket connection problem.
+
+See [troubleshooting.md](troubleshooting.md) for remediation steps for
+each error category, including the typical fixes for `socket_timeout`
+and `engine_api_error`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,6 +2,8 @@
 
 ## Connection problems
 
+These apply to certificate auth mode. For JWT mode see [JWT authentication problems](#jwt-authentication-problems) below.
+
 ### `SSL: CERTIFICATE_VERIFY_FAILED`
 
 The CA certificate path is wrong, the certificate is expired, or the
@@ -33,6 +35,35 @@ client certificate was rejected. Steps:
 3. Confirm the user has at least the `RootAdmin` or `ContentAdmin`
    role, or the equivalent custom role with read access to apps and
    tasks.
+
+## JWT authentication problems
+
+JWT mode (selected when `QLIK_JWT_TOKEN` is set) has its own failure
+profile because the request flows through a Qlik virtual proxy instead
+of hitting the QRS / Engine ports directly. The most common failures:
+
+- **`csrftoken returned 401` — JWT rejected by the virtual proxy.**
+  Token expired, claim names mismatched with QMC, wrong certificate in
+  QMC, or the user is unknown to Qlik. See
+  [`AUTH_JWT.md` → "csrftoken returned 401"](AUTH_JWT.md#csrftoken-returned-401--jwt-rejected-by-the-virtual-proxy).
+- **`csrftoken returned 400` — VP not linked to Central Proxy.** In a
+  multi-node cluster a prefixed VP that is not linked to the Central
+  Proxy is rejected by every proxy with a styled HTML 400 page. See
+  [`AUTH_JWT.md` → "csrftoken returned 400"](AUTH_JWT.md#csrftoken-returned-400--vp-is-not-linked-to-central-proxy).
+- **`csrftoken returned 403` — VP refused.** Hostname in
+  `QLIK_SERVER_URL` is not in the VP **Host allow list**. See
+  [`AUTH_JWT.md` → "csrftoken returned 403"](AUTH_JWT.md#csrftoken-returned-403--vp-refused-the-request).
+- **WebSocket `Handshake status 403 Forbidden`.** Engine WSS upgrade
+  blocked by Qlik November 2024+ CSWSH protection or by a VP / host
+  allow list issue surfacing on the WS leg. See
+  [`AUTH_JWT.md` → "WebSocket fails with Handshake status 403"](AUTH_JWT.md#websocket-fails-with-handshake-status-403-forbidden).
+- **`JWT mode requires a virtual proxy prefix in QLIK_SERVER_URL`.**
+  `QLIK_JWT_TOKEN` is set but `QLIK_SERVER_URL` has no path. See
+  [`AUTH_JWT.md` → "JWT mode requires a virtual proxy prefix"](AUTH_JWT.md#jwt-mode-requires-a-virtual-proxy-prefix-in-qlik_server_url).
+
+For JWT-specific debug logging (bootstrap URL, auto-detected session
+cookie name, CSRF token presence) see the "Everything looks right but
+requests still fail" entry in `docs/AUTH_JWT.md`.
 
 ## Hypercube errors
 
@@ -78,19 +109,37 @@ field. Common causes:
 
 ## Configuration self-test
 
+Field names below mirror `qlik_sense_mcp_server/config.py`
+(`QlikSenseConfig`). The `auth_mode` property resolves to `"jwt"` when
+`QLIK_JWT_TOKEN` is set, otherwise `"certificate"`.
+
 ```bash
 python -c "
 from qlik_sense_mcp_server.config import QlikSenseConfig
 cfg = QlikSenseConfig.from_env()
-print('server_url        =', cfg.server_url)
-print('user_directory    =', cfg.user_directory)
-print('user_id           =', cfg.user_id)
-print('client_cert_path  =', cfg.client_cert_path)
-print('verify_ssl        =', cfg.verify_ssl)
-print('repository_port   =', cfg.repository_port)
-print('engine_port       =', cfg.engine_port)
+print('auth_mode             =', cfg.auth_mode)
+print('server_url            =', cfg.server_url)
+print('qlik_hostname         =', cfg.qlik_hostname)
+print('virtual_proxy_prefix  =', cfg.virtual_proxy_prefix)
+print('user_directory        =', cfg.user_directory)
+print('user_id               =', cfg.user_id)
+print('client_cert_path      =', cfg.client_cert_path)
+print('verify_ssl            =', cfg.verify_ssl)
+print('ca_cert_path          =', cfg.ca_cert_path)
+print('repository_port       =', cfg.repository_port)
+print('engine_port           =', cfg.engine_port)
+print('jwt_token_set         =', bool(cfg.jwt_token))
+print('jwt_user_id_claim     =', cfg.jwt_user_id_claim)
+print('jwt_user_dir_claim    =', cfg.jwt_user_dir_claim)
 "
 ```
+
+In JWT mode the runtime values that matter most (auto-detected session
+cookie name, bootstrap URL, CSRF token presence) are not in the config
+object — they are produced during bootstrap. Run the server with
+`LOG_LEVEL=DEBUG` to see them on the first tool call (see "Verbose
+logging" below and the JWT-specific debug guidance in
+[`AUTH_JWT.md`](AUTH_JWT.md#everything-looks-right-but-requests-still-fail)).
 
 ## Verbose logging
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -124,13 +124,17 @@ print('virtual_proxy_prefix  =', cfg.virtual_proxy_prefix)
 print('user_directory        =', cfg.user_directory)
 print('user_id               =', cfg.user_id)
 print('client_cert_path      =', cfg.client_cert_path)
+print('client_key_path       =', cfg.client_key_path)
 print('verify_ssl            =', cfg.verify_ssl)
 print('ca_cert_path          =', cfg.ca_cert_path)
 print('repository_port       =', cfg.repository_port)
+print('proxy_port            =', cfg.proxy_port)
 print('engine_port           =', cfg.engine_port)
+print('http_port             =', cfg.http_port)
 print('jwt_token_set         =', bool(cfg.jwt_token))
 print('jwt_user_id_claim     =', cfg.jwt_user_id_claim)
 print('jwt_user_dir_claim    =', cfg.jwt_user_dir_claim)
+print('jwt_session_cookie    =', cfg.jwt_session_cookie_override)
 "
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,6 +13,17 @@ The server speaks the two transports defined by the
   writes them to stdout. Use this when your MCP client wants to spawn the
   server as a subprocess on demand.
 
+## Authentication mode
+
+The server can connect to Qlik Sense Enterprise in one of two mutually
+exclusive modes: **certificate** (default — exported client certificate
++ key on port 4242 / 4747) or **JWT** (single bearer token issued
+through a JWT virtual proxy, no client certificate required). The mode
+is chosen by the env vars in your MCP client config; everything else —
+the tool surface, the Streamable HTTP transport, the connection cache —
+behaves identically. See [AUTH_JWT.md](AUTH_JWT.md) for the JWT setup,
+admin CLI and security model.
+
 ## Starting the server
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qlik-sense-mcp-server"
-version = "1.5.0"
+version = "1.5.1"
 description = "MCP Server for Qlik Sense Enterprise APIs"
 readme = "README.md"
 license = {text = "MIT"}

--- a/qlik_sense_mcp_server/__init__.py
+++ b/qlik_sense_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Qlik Sense MCP Server for Enterprise APIs."""
 
-__version__ = "1.4.1"
+__version__ = "1.5.1"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,8 @@
 """Tests for server module (FastMCP-based since v1.4.0)."""
 
 import json
+import re
+from pathlib import Path
 
 from qlik_sense_mcp_server import __version__
 from qlik_sense_mcp_server import server as srv
@@ -35,8 +37,16 @@ class TestVersion:
         for part in parts:
             assert part.isdigit()
 
-    def test_version_is_1_4_1(self):
-        assert __version__ == "1.4.1"
+    def test_version_matches_pyproject(self):
+        # Single source of truth: __version__ must equal the version in
+        # pyproject.toml. Both are bumped together by bump2version on release
+        # (see .bumpversion.cfg). Avoids a hardcoded literal that silently
+        # breaks CI on every version bump.
+        pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+        text = pyproject.read_text(encoding="utf-8")
+        match = re.search(r'^version = "([^"]+)"', text, re.MULTILINE)
+        assert match is not None, "version not found in pyproject.toml"
+        assert __version__ == match.group(1)
 
 
 class TestFastMCPRegistration:


### PR DESCRIPTION
## Summary
- Documentation overhaul of all `.md` files for accuracy against the v1.5.0 source. JWT auth is now surfaced everywhere it matters: `README` highlights and docs index, `docs/configuration.md` (full JWT env-var reference), `docs/installation.md` (cert/JWT branching note), `docs/architecture.md` (`JwtSession` component + `tools/qlik_jwt_admin.py`), `docs/troubleshooting.md` (new JWT-authentication problems section cross-linking into `docs/AUTH_JWT.md`), and `docs/AUTH_JWT.md` (new `Related` index). `COMMANDS.md` was reduced to a true one-page cheatsheet that points at the deeper docs in `docs/`.
- Release-hygiene fix: `qlik_sense_mcp_server/__init__.py` and `.bumpversion.cfg` were not bumped during the 1.5.0 release and still reported `1.4.1`. Brought back in sync with `pyproject.toml` as part of this bump to `1.5.1`.
- Verified against source: `24` tools (3 Repository / 9 Engine / 12 Tasks), JWT env-var names and defaults all match `qlik_sense_mcp_server/config.py` and `qlik_sense_mcp_server/jwt_session.py`, `tools/qlik_jwt_admin.py` CLI flags match doc usage.

## Test plan
- [ ] CI workflow on `release/v1.5.1` is green
- [ ] All cross-references render as live links on GitHub (no 404s in the docs index, README documentation table, AUTH_JWT.md `Related` section, troubleshooting.md JWT anchor links into AUTH_JWT.md)
- [ ] `python -c "import qlik_sense_mcp_server; print(qlik_sense_mcp_server.__version__)"` prints `1.5.1`
- [ ] `pyproject.toml`, `qlik_sense_mcp_server/__init__.py`, and `.bumpversion.cfg` all agree on `1.5.1`
- [ ] After merge: `git tag v1.5.1 && git push origin v1.5.1` triggers PyPI publish via GitHub Actions