### PR TITLE
Release v1.6.0 — top-N hypercube queries

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.5.1
+current_version = 1.6.0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,89 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.6.0] - 2026-07-28
+
+### Added
+- **Real top-N support in `engine_create_hypercube`.** New `sort_by` and
+  `sort_order` parameters order the result by ANY column — a measure
+  label, a measure expression, or a dimension field name (matching
+  ignores case and square brackets). `sort_by` is translated into
+  `qInterColumnSortOrder` with that column first, plus the matching
+  `qSortBy` / `qSortCriterias` direction. Combined with `limit`, this
+  finally answers "the 10 clients with the highest GGR" in one call.
+- **`limit` parameter**, a clearer name for `max_rows`. `max_rows` still
+  works as an alias, so existing callers and saved prompts are
+  unaffected.
+- **`suppress_zero`** to drop rows whose measure is 0 — mainly useful
+  with `sort_order="asc"`, where zero-valued groups would otherwise fill
+  the whole result.
+- **Request echo on every failure.** Any error reply — raised exception
+  or an `{"error": ...}` payload, including timeouts — now carries
+  `tool` and `request` with the exact arguments that produced it. A
+  timeout finally says WHICH query timed out instead of just "timed out
+  after 180s". Implemented once in the `_timed` decorator, so it applies
+  to all tools.
+- **`timings` in the hypercube response**, split into
+  `open_app_seconds` (loading the app into Engine memory, paid only by
+  the first call against an app) and `get_layout_seconds` (the actual
+  computation) — so a slow call can be attributed instead of guessed at.
+- **Usage examples in every tool docstring**, with realistic arguments
+  and a shortened but structurally correct response.
+- **Qlik session-limit warning in the Engine tool docstrings and in
+  `docs/AUTH_JWT.md`**: Qlik permits at most 5 concurrent sessions per
+  user identity and can lock the account beyond that, so tool calls must
+  never be fanned out in parallel. This server deliberately funnels
+  everything through one cached Engine session.
+- `tests/test_hypercube.py` and `tests/test_tool_registration.py` — 52
+  new tests covering sort resolution, the generated `qHyperCubeDef`,
+  guard rails, the request echo and per-mode tool visibility.
+
+### Changed
+- **Reload-task tools are registered in certificate mode only.** They
+  call QRS endpoints that require repository-admin rights, which a JWT
+  analyst does not have, so JWT mode now advertises 12 tools instead of
+  24 rather than offering 12 that can only return 403.
+- **The hypercube response is compact by default.** It now returns
+  `columns` plus `rows` (plain values — numbers stay numbers) together
+  with `grand_total`, instead of the raw `qHyperCube` with its per-cell
+  `qElemNumber`/`qState` metadata. Pass `include_raw_layout=true` to get
+  the full Qlik layout back.
+- **`engine_create_hypercube`'s docstring was rewritten** around a
+  SQL analogy and three worked examples, and no longer recommends
+  `qSortByExpression` for ranking. Measured on a 91M-row table: sorting
+  by the measure column runs in 0.2s where `qSortByExpression` took
+  286s, because the latter makes the Engine compute the same aggregate a
+  second time purely to order rows.
+- **The `socket_timeout` hint now lists fixes in order of impact** and
+  names the correct environment variable (`QLIK_WS_TIMEOUT`; it
+  previously pointed at `QLIK_WS_OPERATION_TIMEOUT`, which does not
+  exist).
+- Truncation warnings distinguish a ranked query (expected: "showing the
+  10 highest rows of 1217") from an unsorted one (a real problem: the
+  returned rows are arbitrary).
+
+### Fixed
+- **Sorting by a measure never worked.** `qInterColumnSortOrder` was
+  hard-coded to `list(range(n_cols))`, so the first dimension always won
+  and the per-measure `qSortBy` was dead configuration. Any "top 10 by
+  revenue" request silently returned 10 alphabetically-first rows —
+  plausible-looking data in the wrong order. Verified against a live
+  91M-row app: the new ordering matches a reference sort computed
+  independently over all 1217 groups.
+- **`create_hypercube` mutated its caller's dictionaries**, injecting
+  default `sort_by` keys into the passed-in `dimensions` / `measures`
+  and then returning them as the "echoed input".
+- **Hypercube session objects were never released.** Each call left its
+  session object alive, pinning the result set in Engine memory for the
+  rest of the session; they are now destroyed after the data is read.
+- `DEFAULT_HYPERCUBE_MAX_ROWS` was imported in `engine_api.py` but
+  unused, while the default was hard-coded to 1000 in the signature.
+- Docstring corrections: `get_apps` documented QRS field names
+  (`modifiedDate`, `lastReloadTime`, `published`, `fileSize`) that the
+  tool does not return — it returns `modified_dttm` / `reload_dttm`;
+  `get_task_executions` documented snake_case keys where QRS returns
+  camelCase with `duration` in milliseconds.
+
 ## [1.5.1] - 2026-04-27
 
 ### Changed

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -43,15 +43,32 @@ See `docs/development.md` for tests, lint, and contribution flow.
 ## Release
 
 ```bash
-# Bump version, open PR (current line: 1.5.0)
-make version-patch  # 1.5.0 -> 1.5.1
-make version-minor  # 1.5.0 -> 1.6.0
-make version-major  # 1.5.0 -> 2.0.0
+# Bump version, open PR (current line: 1.6.0)
+make version-patch  # 1.6.0 -> 1.6.1
+make version-minor  # 1.6.0 -> 1.7.0
+make version-major  # 1.6.0 -> 2.0.0
 
 # After PR merge: tag and push — GitHub Actions publishes to PyPI
-git tag v1.5.1
-git push origin v1.5.1
+git tag v1.6.0
+git push origin v1.6.0
 ```
+
+## Query a top-N (the most common analysis call)
+
+```jsonc
+// engine_create_hypercube — GROUP BY + ORDER BY + LIMIT in one call
+{
+  "app_id": "<app guid>",
+  "dimensions": [{"field": "clientid"}],
+  "measures":   [{"expression": "Sum(ggr)", "label": "GGR"}],
+  "sort_by": "GGR",        // measure label, measure expression or dimension field
+  "sort_order": "desc",    // "asc" for bottom-N
+  "limit": 10
+}
+```
+
+Never fan these calls out in parallel — Qlik allows max 5 concurrent
+sessions per user and can lock the account. See `docs/usage.md`.
 
 ## JWT (admin)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 Qlik Sense Enterprise. Exposes Qlik's Repository (HTTP) and Engine
 (WebSocket) APIs as **24 MCP tools** so an LLM client can discover apps,
 inspect data models, build hypercubes, and manage reload tasks through
-a single uniform interface.
+a single uniform interface. In JWT mode the 12 reload-task tools are
+hidden, since QRS task administration needs certificate auth.
 
 ## What's in the box
 
@@ -17,9 +18,25 @@ a single uniform interface.
 |------|-------|----------|
 | Repository (apps & metadata) | `get_about`, `get_apps`, `get_app_details` | Discover apps, list tables and fields with cardinalities |
 | Engine (data & script)       | `get_app_script`, `get_app_variables`, `get_app_sheets`, `get_app_sheet_objects`, `get_app_object`, `get_app_field`, `engine_get_field_range`, `get_app_field_statistics`, `engine_create_hypercube` | Read load script, list visualizations, query field values, build hypercubes |
-| Reload tasks                 | `get_tasks`, `get_task_details`, `get_task_dependencies`, `get_task_schedule`, `get_task_executions`, `get_task_script_log`, `get_failed_tasks_with_logs`, `start_task`, `create_task`, `update_task`, `delete_task`, `create_task_schedule` | Inspect, trigger and manage reload tasks |
+| Reload tasks *(certificate mode only)* | `get_tasks`, `get_task_details`, `get_task_dependencies`, `get_task_schedule`, `get_task_executions`, `get_task_script_log`, `get_failed_tasks_with_logs`, `start_task`, `create_task`, `update_task`, `delete_task`, `create_task_schedule` | Inspect, trigger and manage reload tasks |
 
 Full list with descriptions: [`docs/tools.md`](docs/tools.md).
+
+The main analysis call maps onto SQL one-to-one — `dimensions` is the
+`GROUP BY`, `measures` are the aggregates, `sort_by` / `sort_order` are
+the `ORDER BY`, `limit` is the `LIMIT`:
+
+```jsonc
+// engine_create_hypercube — "the 10 clients with the highest GGR"
+{
+  "app_id": "<app guid>",
+  "dimensions": [{"field": "clientid"}],
+  "measures":   [{"expression": "Sum(ggr)", "label": "GGR"}],
+  "sort_by": "GGR",
+  "sort_order": "desc",
+  "limit": 10
+}
+```
 
 ## Quick start
 
@@ -51,8 +68,28 @@ secrets). See [`docs/AUTH_JWT.md`](docs/AUTH_JWT.md) for the JWT setup.
 | [`docs/troubleshooting.md`](docs/troubleshooting.md) | Common errors, hypercube planning failures, verbose logging, configuration self-test |
 | [`CHANGELOG.md`](CHANGELOG.md) | Release notes |
 
-## Key facts about the v1.5.0 line
+## Key facts about the v1.6.0 line
 
+- **Ranked queries (top-N) in one call.** `engine_create_hypercube`
+  takes `sort_by` (a measure label, a measure expression or a dimension
+  field), `sort_order` (`desc` / `asc`) and `limit`, so "the 10 clients
+  with the highest GGR" is a single request. Before v1.6.0 sorting by a
+  measure silently did nothing — `qInterColumnSortOrder` was hard-coded
+  to the dimensions, so the server returned the alphabetically first
+  rows instead of the largest ones.
+- **Compact, LLM-friendly results.** The hypercube response is
+  `columns` + `rows` with real numbers, plus `grand_total` and
+  per-step `timings`. Pass `include_raw_layout=true` for the full Qlik
+  layout.
+- **Failures name the query that failed.** Every error reply, timeouts
+  included, echoes `tool` and `request` with the exact arguments sent.
+- **Fewer useless tools in JWT mode.** Reload-task administration needs
+  QRS admin rights, so those 12 tools are registered only in
+  certificate mode: 24 tools with a certificate, 12 with a JWT.
+- **One Qlik session per server.** Qlik allows max 5 concurrent
+  sessions per user and can lock the account beyond that, so all tool
+  calls share a single cached Engine session — never fan them out in
+  parallel.
 - **JWT authentication via virtual proxy.** Set `QLIK_JWT_TOKEN`
   instead of certificate paths and the server will authenticate every
   Repository and Engine call as the analyst encoded in the token. No

--- a/docs/AUTH_JWT.md
+++ b/docs/AUTH_JWT.md
@@ -167,6 +167,32 @@ something non-standard.
 | `QLIK_VERIFY_SSL` | `false` disables TLS verification | `true` |
 | `QLIK_CA_CERT_PATH` | Path to a corporate CA bundle | unset |
 
+### 2.4 Session limit — run ONE session per token
+
+**Qlik allows at most 5 concurrent sessions per user identity.** Every
+JWT is issued for one analyst, so all of that analyst's MCP activity
+shares the same 5-session budget. Exceeding it does not simply queue —
+Qlik treats it as abuse and can **lock the account**.
+
+Practical rules:
+
+- Run **one** MCP server process per token, and keep it running. The
+  server reuses a single Engine WebSocket and a single bootstrapped
+  session for every tool call, so a long-running process costs exactly
+  one session no matter how many queries you send through it.
+- Do **not** start the same `mcp.json` entry from several editors at
+  once (Cursor + Claude Code + Claude Desktop side by side), and do not
+  hand the same token to two people.
+- Do not run parallel MCP clients "to make things faster" — the tools
+  are serialised over one socket anyway, so extra sessions buy nothing
+  and risk the lockout.
+- If an analyst is locked out, wait for the sessions to expire (default
+  Qlik idle timeout is 30 minutes) or have an admin drop them in the
+  QMC session monitor.
+
+This is a Qlik Sense platform limit, not something this MCP server can
+raise or work around.
+
 ---
 
 ## How it works under the hood

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,6 +100,50 @@ cascading the failure for the rest of the session. Now any timeout or
 parse error force-closes the socket via `_kill_socket()`, the cache is
 invalidated, and the next call opens a fresh connection.
 
+#### Hypercube sorting (since v1.6.0)
+
+`create_hypercube` accepts `sort_by` (a measure label, a measure
+expression, or a dimension field name) plus `sort_order`, and translates
+them into two coordinated parts of `qHyperCubeDef`:
+
+1. `qInterColumnSortOrder` is rebuilt with the requested column first.
+   Column indices are fixed by the Engine: dimensions occupy `0..D-1`,
+   measures `D..D+M-1`. This is the only mechanism that makes the Engine
+   order rows by a measure.
+2. The direction is written to that column's own criteria — `qSortBy`
+   (`qSortByNumeric` ±1) for a measure, `qSortCriterias` with both
+   `qSortByNumeric` and `qSortByAscii` for a dimension, so numeric and
+   text fields both sort correctly without the caller knowing the type.
+
+Both halves are required: a measure whose `qSortBy` is left at the Engine
+default ("ascending alphabetic") produces a nonsense order even when it
+leads `qInterColumnSortOrder`.
+
+Before v1.6.0 `qInterColumnSortOrder` was hard-coded to
+`list(range(n_cols))`, so the first dimension always won and per-measure
+sorting was dead configuration — top-N requests silently returned the
+alphabetically first rows.
+
+Ranking this way is also much cheaper than the `qSortByExpression`
+alternative, which makes the Engine evaluate the aggregate a second time
+purely to order rows. Measured against a live 91M-row app: 0.2s versus
+286s.
+
+Unknown `sort_by` / `sort_order` values fail fast with an
+`invalid_sort` error listing `available_columns`, before any Engine call
+— silently ignoring a sort would return plausible rows in the wrong
+order, which is worse than an error.
+
+#### Response shape
+
+The tool returns `columns` + `rows` (plain values, numbers preserved),
+`grand_total`, `sorted_by` / `sort_order`, and `timings` split into
+`open_app_seconds` and `get_layout_seconds`. The raw `qHyperCube` with
+per-cell `qElemNumber`/`qState` is opt-in via `include_raw_layout`,
+because it costs several times more tokens. The session object is
+destroyed once its data has been read, so results are not pinned in
+Engine memory for the rest of the session.
+
 #### Two-tier timeouts
 
 A single `QLIK_WS_TIMEOUT` environment variable (default `180.0s`)
@@ -120,9 +164,28 @@ tool is also wrapped in the local `_timed` decorator, which:
 1. Measures wall-clock time of the call.
 2. Injects `tool_call_seconds` as the **first** key of the JSON
    response.
-3. On exception, returns a structured `{tool_call_seconds, error,
-   error_type, tool}` envelope instead of letting the MCP layer turn
-   the traceback into something opaque.
+3. On failure, returns a structured `{tool_call_seconds, error,
+   error_type, tool, request}` envelope instead of letting the MCP layer
+   turn the traceback into something opaque. `request` is the exact
+   argument set the tool was called with, reconstructed from the
+   function signature via `inspect.signature().bind_partial()`. It is
+   attached both to raised exceptions and to `{"error": ...}` payloads
+   that tools return themselves (timeouts, bad field names, limit
+   violations) — a bare "timed out after 180s" does not tell the caller
+   which query to fix.
+
+#### Per-mode tool registration (since v1.6.0)
+
+Reload-task tools are declared with `@_cert_only_tool()` instead of
+`@mcp.tool()`. That decorator registers the function only when
+`config.auth_mode != jwt`, because QRS task administration
+(`/qrs/reloadtask`, `/qrs/executionresult`, script-log download)
+requires repository-admin rights that a JWT analyst identity does not
+have. JWT sessions therefore see 12 tools instead of 24, rather than 12
+that can only return 403.
+
+When the configuration fails to load entirely (`config is None`) every
+tool stays registered — that path serves `--help` and the test suite.
 
 The server runs in
 [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports)

--- a/docs/development.md
+++ b/docs/development.md
@@ -28,6 +28,19 @@ Pytest discovers everything under [`tests/`](../tests/):
 pytest
 ```
 
+The suite is offline — no Qlik server is required. Engine behaviour is
+covered by driving `create_hypercube` against a fake `send_request` and
+asserting on the generated `qHyperCubeDef`
+([`tests/test_hypercube.py`](../tests/test_hypercube.py)), which is how
+the sorting contract (`qInterColumnSortOrder`, per-column direction) is
+pinned down. Tool visibility per authentication mode is covered by
+re-importing `server.py` under different environments
+([`tests/test_tool_registration.py`](../tests/test_tool_registration.py)).
+
+Changes to Engine query building should still be smoke-tested against a
+real app before release — the offline tests verify the request we send,
+not what Qlik does with it.
+
 ## Versioning
 
 The project uses [bump2version](https://pypi.org/project/bump2version/)
@@ -73,11 +86,22 @@ The PyPI package version is read from `pyproject.toml`.
            return _err(str(ex))
    ```
 3. Both decorators are required:
-   - `@mcp.tool()` registers the function with FastMCP.
+   - `@mcp.tool()` registers the function with FastMCP. Use
+     `@_cert_only_tool()` instead if the tool needs QRS admin rights
+     (reload-task administration) — it registers the tool in
+     certificate mode only, so JWT analysts are not offered calls that
+     can only return 403.
    - `@_timed` wraps the response with `tool_call_seconds` and a
-     structured error envelope.
-4. Update [`docs/tools.md`](tools.md).
-5. Update [`CHANGELOG.md`](../CHANGELOG.md).
+     structured error envelope, and echoes the failing `request` back
+     to the caller. You get both for free; do not hand-roll them.
+4. Write the docstring for an LLM, not for a human reader. Every tool
+   ends with an `Example:` block showing a realistic `Call:` and a
+   shortened but structurally correct `Returns:`. Document the actual
+   response keys — a docstring that promises keys the tool does not
+   return is worse than no docstring, because the model will build its
+   next call around them.
+5. Update [`docs/tools.md`](tools.md).
+6. Update [`CHANGELOG.md`](../CHANGELOG.md).
 
 New tools normally do not need any JWT-aware code: cert vs JWT auth is
 abstracted inside `QlikRepositoryAPI` / `QlikEngineAPI`, and the

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,10 +1,20 @@
 # Tools
 
-The server exposes **24** MCP tools, grouped into three areas:
+The server exposes up to **24** MCP tools, grouped into three areas:
 
 - **Repository API** — fast metadata via Qlik Repository (HTTP/QRS).
 - **Engine API** — data and load script via Qlik Engine (WebSocket).
 - **Task management** — reload tasks, schedules, executions, script logs.
+
+**Availability depends on the authentication mode.** Task management
+calls QRS endpoints that require repository-admin rights, which a JWT
+analyst identity does not have, so those 12 tools are registered in
+certificate mode only:
+
+| Mode | Tools registered |
+|------|------------------|
+| certificate | 24 — everything below |
+| JWT (virtual proxy) | 12 — Repository metadata + Engine only |
 
 Every tool returns its full parameter documentation via the standard MCP
 `tools/list` request. Use that as the authoritative reference — the
@@ -32,7 +42,7 @@ categories. The lists below are a quick map only.
 | `get_app_field` | Distinct values of one field with pagination and wildcard search. Falls back to a single-dimension hypercube if the underlying `ListObject` returns nothing. |
 | `engine_get_field_range` | Lightning-fast bounds for one field: count distinct, min, max. Implemented as a measures-only hypercube — runs in seconds on any table size. Prefer this over `get_app_field_statistics`. |
 | `get_app_field_statistics` | Field statistics via a measures-only hypercube. Defaults to **light** mode (count distinct, count, non-null count, min, max, null %, completeness). Pass `full=true` to also compute avg / sum / median / mode / stdev — slow on big fact tables and meaningless for date/text fields. |
-| `engine_create_hypercube` | Build an arbitrary `GROUP BY` hypercube. The main data-analysis tool. Hard limits: `max_rows <= 5000`, `columns * max_rows <= 9900`. Read the full docstring — it covers set-analysis patterns, the no-expression-in-dimension rule, top-N patterns, and the SLICE-BY-CATEGORY workflow for data that won't fit in one cube. |
+| `engine_create_hypercube` | Build an arbitrary `GROUP BY` hypercube — the main data-analysis tool. Supports ranking directly: `sort_by` (measure label / measure expression / dimension field) + `sort_order` (`desc` / `asc`) + `limit`. Hard limits: `limit <= 5000`, `columns * limit <= 9900`. Read the full docstring — it covers set-analysis patterns, the no-expression-in-dimension rule and the session limit. |
 
 ## Task management (Repository API)
 
@@ -68,6 +78,11 @@ Every tool wraps its result in:
 `tool_call_seconds` is always the first key. Use it to find the slow
 calls in a session at a glance.
 
+`engine_create_hypercube` returns its data as `columns` + `rows` (plain
+values; numbers stay numbers) plus `grand_total`, `sorted_by`,
+`sort_order` and `timings`. Pass `include_raw_layout=true` if you need
+the untouched Qlik `qHyperCube` with per-cell `qElemNumber`/`qState`.
+
 ## Error envelope
 
 On failure, tools return:
@@ -80,16 +95,24 @@ On failure, tools return:
   "error_category": "socket_timeout", // see below
   "failed_step": "GetLayout",         // or CreateSessionObject, plan, ensure_app
   "hint": "what to do next",
+  "tool": "engine_create_hypercube",
+  "request": { "app_id": "...", "limit": 5000 },  // the exact arguments sent
   "traceback": "..."
 }
 ```
 
+`tool` and `request` are present on every failure, timeouts included —
+so a failed call always tells you *which* query failed, not just that
+something timed out.
+
 The categories you can see from `engine_create_hypercube`:
 
-- `limit_exceeded` — `max_rows > 5000`. Redesign as top-N or
+- `invalid_sort` — `sort_by` matched no column, or `sort_order` was not
+  `asc`/`desc`. The response lists `available_columns`.
+- `limit_exceeded` — `limit > 5000`. Redesign as top-N or
   slice-by-category.
-- `cell_cap_exceeded` — `columns * max_rows > 9900`. Drop columns or
-  reduce `max_rows`. The hint contains an exact suggested value.
+- `cell_cap_exceeded` — `columns * limit > 9900`. Drop columns or
+  reduce `limit`. The hint contains an exact suggested value.
 - `socket_timeout` — Engine is genuinely computing something slow. Add
   more set-analysis filters, reduce `max_rows`, or switch to top-N.
 - `engine_api_error` — invalid expression / unknown field. The full

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -71,16 +71,27 @@ requests still fail" entry in `docs/AUTH_JWT.md`.
 
 Engine is genuinely computing something slow. Order of fixes:
 
+The error reply echoes `request` — the exact arguments you sent — so
+start by reading which query actually timed out, then apply the fixes in
+this order:
+
 1. **Add a set-analysis filter** inside every measure. Narrowing the
    period or category by even one value usually cuts the cost by
    orders of magnitude on a wide fact table.
-2. **Reduce `max_rows`.** The hard server cap is 5000, but for top-N
+2. **Reduce `limit`.** The hard server cap is 5000, but for top-N
    queries you almost always want 15-50.
-3. **Drop a high-cardinality dimension** if you have one. Sorting a
-   dimension with one million distinct values by a measure expression
-   forces a full materialization. Use the SLICE-BY-CATEGORY pattern
-   from the `engine_create_hypercube` docstring instead.
-4. As a last resort, raise `QLIK_WS_TIMEOUT` (e.g. to `300.0`) to
+3. **Rank with `sort_by`, not `qSortByExpression`.** Passing
+   `sort_by="<measure label>"` orders by the already-computed measure
+   column. Hand-rolling `qSortByExpression` on the dimension makes the
+   Engine evaluate the same aggregate a second time purely to sort:
+   measured on a 91M-row app, 0.2s versus 286s.
+4. **Group by a field closer to the facts.** Check `timings` in the
+   response — if `get_layout_seconds` is tens of seconds while
+   `open_app_seconds` is small, the grouping field is usually on the far
+   side of a large link table. A dimension inside the fact table itself
+   returns in well under a second even at 91M rows.
+5. **Drop a high-cardinality dimension** if you have one.
+6. As a last resort, raise `QLIK_WS_TIMEOUT` (e.g. to `300.0`) to
    give the Engine more time. Do not raise it for the entire MCP
    session — most of the time the right answer is to redesign the
    query.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -73,10 +73,45 @@ The intended call order for any analysis session is:
    the dimension-expression antipattern, and the hard 5000-row /
    9900-cell limits the server enforces.
 
+## Ranking (top-N / bottom-N)
+
+`engine_create_hypercube` maps onto SQL one-to-one: `dimensions` is the
+`GROUP BY`, `measures` are the aggregates, `sort_by` + `sort_order` are
+the `ORDER BY`, and `limit` is the `LIMIT`. "The 10 clients with the
+highest GGR" is one call:
+
+```jsonc
+{
+  "app_id": "…",
+  "dimensions": [{"field": "clientid"}],
+  "measures": [{"expression": "Sum(ggr)", "label": "GGR"}],
+  "sort_by": "GGR",          // measure label, measure expression or dimension field
+  "sort_order": "desc",      // "asc" for bottom-N
+  "limit": 10
+}
+```
+
+`sort_by` puts that column first in Qlik's `qInterColumnSortOrder`,
+which is the only way the Engine orders rows by a measure. Do **not**
+hand-roll `qSortByExpression` on the dimension for ranking: it makes the
+Engine evaluate the same aggregate a second time just to order rows. On
+a 91M-row app, ranking by the measure column returned in 0.2s where the
+`qSortByExpression` form took 286s.
+
+## One session at a time
+
+Qlik Sense allows at most **5 concurrent sessions per user identity**,
+and exceeding that can get the account **locked** — a platform limit no
+MCP setting can raise. This server funnels every tool call through a
+single cached Engine session, so an entire analysis costs one session.
+Keep it that way: never fan out tool calls in parallel (they are
+serialised over one WebSocket anyway), and do not run a second MCP
+process or a second editor against the same credentials.
+
 ## Hard limits enforced by this server
 
-- `engine_create_hypercube`: `max_rows` is capped at **5000**, and the
-  total `columns * max_rows` is capped at **9900** (Qlik Engine itself
+- `engine_create_hypercube`: `limit` (alias `max_rows`) is capped at
+  **5000**, and the total `columns * limit` is capped at **9900** (Qlik Engine itself
   refuses pages over 10000 cells per `GetHyperCubeData` call —
   [error 7009 `calc-pages-too-large`](https://help.qlik.com/en-US/sense-developer/November2025/Subsystems/EngineJSONAPI/Content/service-genericobject-gethypercubedata.htm)).
   Requests over the limits are rejected immediately with a
@@ -100,9 +135,22 @@ standard MCP `tools/list` response.
 
 ## Diagnostics
 
-Every tool response now starts with a `tool_call_seconds` field —
+Every tool response starts with a `tool_call_seconds` field —
 wall-clock time of the call rounded to milliseconds. Use it to spot the
 slow tools in a session.
+
+`engine_create_hypercube` additionally returns `timings`, which splits
+that number into `open_app_seconds` (loading the app into Engine memory
+— only the first call against an app pays it) and
+`get_layout_seconds` (the computation itself). A large
+`get_layout_seconds` means the query is genuinely heavy: add set
+analysis, drop a dimension, or group by a field that sits closer to the
+fact table. A well-formed query answers in seconds — grouping by a field
+inside a 91M-row fact table returns in well under a second.
+
+Every failed call — including timeouts — echoes back `tool` and
+`request` with the exact arguments that produced it, so you can see
+which query failed and retry with a cheaper one instead of guessing.
 
 For deeper diagnosis, set `LOG_LEVEL=DEBUG` in your env block. Each
 hypercube call then logs `CreateSessionObject`, `GetLayout` and any

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qlik-sense-mcp-server"
-version = "1.5.1"
+version = "1.6.0"
 description = "MCP Server for Qlik Sense Enterprise APIs"
 readme = "README.md"
 license = {text = "MIT"}

--- a/qlik_sense_mcp_server/__init__.py
+++ b/qlik_sense_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Qlik Sense MCP Server for Enterprise APIs."""
 
-__version__ = "1.5.1"
+__version__ = "1.6.0"

--- a/qlik_sense_mcp_server/engine_api.py
+++ b/qlik_sense_mcp_server/engine_api.py
@@ -1073,18 +1073,151 @@ class QlikEngineAPI:
         result = self.send_request("GetField", params, handle=app_handle)
         return result
 
+    # Sort-direction aliases accepted from LLM callers. Qlik encodes the
+    # direction as -1 (descending) / 1 (ascending) / 0 (criterion disabled).
+    _SORT_ORDER_ALIASES = {
+        "desc": -1, "descending": -1, "down": -1, "high": -1,
+        "highest": -1, "top": -1, "-1": -1,
+        "asc": 1, "ascending": 1, "up": 1, "low": 1,
+        "lowest": 1, "bottom": 1, "1": 1,
+    }
+
+    @staticmethod
+    def _normalize_sort_order(sort_order: Any) -> Optional[int]:
+        """
+        Map a human/LLM-supplied sort direction onto Qlik's -1 / 1.
+
+        Returns None when the value is not recognised, so the caller can
+        answer with an explicit error instead of silently sorting the
+        wrong way round.
+        """
+        if isinstance(sort_order, bool):
+            return None
+        if isinstance(sort_order, int):
+            return sort_order if sort_order in (-1, 1) else None
+        if isinstance(sort_order, str):
+            return QlikEngineAPI._SORT_ORDER_ALIASES.get(sort_order.strip().lower())
+        return None
+
+    @staticmethod
+    def _column_names(
+        converted_dimensions: List[Dict[str, Any]],
+        converted_measures: List[Dict[str, Any]],
+    ) -> List[str]:
+        """
+        Human-readable column names in hypercube column order.
+
+        Column order is fixed by the Engine API: every dimension first
+        (0..D-1, in declaration order), then every measure (D..D+M-1).
+        """
+        names = [str(d.get("field", "")) for d in converted_dimensions]
+        for i, m in enumerate(converted_measures):
+            names.append(str(m.get("label") or m.get("expression") or f"Measure_{i}"))
+        return names
+
+    @staticmethod
+    def _matrix_to_rows(
+        data_pages: List[Dict[str, Any]],
+        column_names: List[str],
+    ) -> List[List[Any]]:
+        """
+        Flatten Engine's qMatrix into plain rows of values.
+
+        Each Engine cell is `{qText, qNum, qElemNumber, qState}`; consumers
+        of this tool only ever need the value, and `qNum == "NaN"` is
+        Engine's way of saying "this cell is text or empty". Returning
+        numbers as numbers means an LLM can compare and sum them without
+        first parsing locale-formatted strings like "95 552 568 044,926".
+        """
+        rows: List[List[Any]] = []
+        for page in data_pages or []:
+            for matrix_row in page.get("qMatrix", []) or []:
+                row: List[Any] = []
+                for cell in matrix_row:
+                    num = cell.get("qNum")
+                    row.append(cell.get("qText") if num == "NaN" or num is None else num)
+                rows.append(row)
+        return rows
+
+    @staticmethod
+    def _resolve_sort_column(
+        sort_by: Any,
+        converted_dimensions: List[Dict[str, Any]],
+        converted_measures: List[Dict[str, Any]],
+    ) -> Optional[int]:
+        """
+        Resolve `sort_by` to a hypercube column index, or None if unknown.
+
+        Accepts, in this order of preference:
+          * an int — used directly as a column index;
+          * a measure label, a measure expression, or the auto-generated
+            `Measure_<i>` name;
+          * a dimension field name.
+        Matching is case-insensitive and tolerates surrounding square
+        brackets, because LLMs routinely write `[Sales]` for a field.
+        """
+        n_dims = len(converted_dimensions)
+        n_cols = n_dims + len(converted_measures)
+
+        if isinstance(sort_by, bool):
+            return None
+        if isinstance(sort_by, int):
+            return sort_by if 0 <= sort_by < n_cols else None
+        if not isinstance(sort_by, str):
+            return None
+
+        def _key(value: Any) -> str:
+            return str(value or "").strip().strip("[]").casefold()
+
+        target = _key(sort_by)
+        if not target:
+            return None
+
+        # Measures win over dimensions: "sort by Sales" almost always means
+        # the aggregate, and a measure label may legitimately repeat the
+        # name of the field it aggregates.
+        for i, measure in enumerate(converted_measures):
+            candidates = {
+                _key(measure.get("label")),
+                _key(measure.get("expression")),
+                _key(f"Measure_{i}"),
+            }
+            if target in candidates - {""}:
+                return n_dims + i
+
+        for i, dim in enumerate(converted_dimensions):
+            if target == _key(dim.get("field")):
+                return i
+
+        return None
+
     def create_hypercube(
         self,
         app_handle: int,
         dimensions: List[Dict[str, Any]] = None,
         measures: List[Dict[str, Any]] = None,
-        max_rows: int = 1000,
+        max_rows: int = DEFAULT_HYPERCUBE_MAX_ROWS,
+        sort_by: Optional[Any] = None,
+        sort_order: str = "desc",
+        suppress_zero: bool = False,
+        include_raw_layout: bool = False,
     ) -> Dict[str, Any]:
-        """Create hypercube for data extraction with proper structure."""
+        """
+        Create a hypercube (grouped aggregation) and return its first page.
+
+        `sort_by` names the column that drives the row order — a measure
+        label/expression or a dimension field name. It is translated into
+        `qInterColumnSortOrder` with that column first, which is the only
+        way the Engine sorts rows by a measure. Sorting by an already
+        computed measure column costs nothing extra, unlike
+        `qSortByExpression`, which makes the Engine evaluate the aggregate
+        a second time purely for ordering.
+        """
         import time
         import traceback as _tb
         step = "init"
         t0 = time.monotonic()
+        timings: Dict[str, float] = {}
         try:
             # Handle empty dimensions/measures
             if dimensions is None:
@@ -1092,50 +1225,35 @@ class QlikEngineAPI:
             if measures is None:
                 measures = []
 
-            # Convert old format (list of strings) to new format (list of dicts) for backward compatibility
+            # Normalise both the legacy string form and the dict form into
+            # dicts. Every branch COPIES the caller's dict — mutating the
+            # argument in place would leak our defaults back into the
+            # caller's data and make `dimensions` in the response something
+            # other than the echoed input it claims to be.
             converted_dimensions = []
             for dim in dimensions:
                 if isinstance(dim, str):
-                    # Old format - just field name
-                    converted_dimensions.append({
-                        "field": dim,
-                        "sort_by": {
-                            "qSortByNumeric": 0,
-                            "qSortByAscii": 1,  # Default: ASCII ascending
-                            "qSortByExpression": 0,
-                            "qExpression": ""
-                        }
-                    })
+                    dim = {"field": dim}
                 else:
-                    # New format - dict with field and sort options
-                    # Set defaults if not specified
-                    if "sort_by" not in dim:
-                        dim["sort_by"] = {
-                            "qSortByNumeric": 0,
-                            "qSortByAscii": 1,  # Default: ASCII ascending
-                            "qSortByExpression": 0,
-                            "qExpression": ""
-                        }
-                    converted_dimensions.append(dim)
+                    dim = dict(dim)
+                dim.setdefault("sort_by", {
+                    "qSortByNumeric": 0,
+                    "qSortByAscii": 1,  # Default: ASCII ascending
+                    "qSortByExpression": 0,
+                    "qExpression": "",
+                })
+                converted_dimensions.append(dim)
 
             converted_measures = []
             for measure in measures:
                 if isinstance(measure, str):
-                    # Old format - just expression
-                    converted_measures.append({
-                        "expression": measure,
-                        "sort_by": {
-                            "qSortByNumeric": -1  # Default: numeric descending
-                        }
-                    })
+                    measure = {"expression": measure}
                 else:
-                    # New format - dict with expression and sort options
-                    # Set defaults if not specified
-                    if "sort_by" not in measure:
-                        measure["sort_by"] = {
-                            "qSortByNumeric": -1  # Default: numeric descending
-                        }
-                    converted_measures.append(measure)
+                    measure = dict(measure)
+                # Default: numeric descending. Only takes effect once this
+                # measure is the leading column of qInterColumnSortOrder.
+                measure.setdefault("sort_by", {"qSortByNumeric": -1})
+                converted_measures.append(measure)
 
             # Hard limits enforced in our layer — NOT in Qlik Engine.
             # The intent is to force the LLM to design narrow, focused
@@ -1146,6 +1264,55 @@ class QlikEngineAPI:
             HARD_MAX_ROWS = 5000
             HARD_MAX_CELLS = 9900  # Qlik's own cell cap per NxPage is 10k
             n_cols = len(converted_dimensions) + len(converted_measures)
+            n_dims = len(converted_dimensions)
+            column_names = self._column_names(converted_dimensions, converted_measures)
+
+            # ── Resolve the requested sort ────────────────────────────────
+            # Both failures below are caller mistakes, so they are reported
+            # as structured `plan` errors listing the valid options rather
+            # than being silently ignored — a silently ignored sort returns
+            # plausible-looking rows in the wrong order, which is worse
+            # than an error.
+            step = "plan"
+            sort_column_index: Optional[int] = None
+            sort_direction: Optional[int] = None
+            if sort_by is not None and n_cols > 0:
+                sort_direction = self._normalize_sort_order(sort_order)
+                if sort_direction is None:
+                    return {
+                        "error": (
+                            f"sort_order={sort_order!r} is not a valid sort "
+                            f"direction."
+                        ),
+                        "error_category": "invalid_sort",
+                        "failed_step": "plan",
+                        "hint": (
+                            "Use sort_order=\"desc\" for largest-first "
+                            "(top-N) or sort_order=\"asc\" for "
+                            "smallest-first (bottom-N)."
+                        ),
+                    }
+                sort_column_index = self._resolve_sort_column(
+                    sort_by, converted_dimensions, converted_measures
+                )
+                if sort_column_index is None:
+                    return {
+                        "error": (
+                            f"sort_by={sort_by!r} does not match any column "
+                            f"of this hypercube."
+                        ),
+                        "error_category": "invalid_sort",
+                        "failed_step": "plan",
+                        "available_columns": column_names,
+                        "hint": (
+                            "sort_by must name one of the columns listed in "
+                            "`available_columns` — a measure label, a "
+                            "measure expression, or a dimension field name "
+                            "(matching ignores case and square brackets). "
+                            "To rank by an aggregate, give the measure a "
+                            "`label` and pass that same label as sort_by."
+                        ),
+                    }
 
             # Reject max_rows over the hard cap.
             if max_rows > HARD_MAX_ROWS:
@@ -1212,6 +1379,41 @@ class QlikEngineAPI:
                 n_cols * first_page_height, HARD_MAX_CELLS,
             )
 
+            # ── Apply the resolved sort ───────────────────────────────────
+            # qInterColumnSortOrder decides WHICH column drives the row
+            # order; the column's own criteria decide the DIRECTION. Both
+            # halves are required: a measure whose qSortBy is left at the
+            # Engine default ("ascending alphabetic") produces a nonsense
+            # order even when it leads qInterColumnSortOrder.
+            inter_column_sort_order = list(range(n_cols))
+            suppress_missing = False
+            if sort_column_index is not None and sort_direction is not None:
+                inter_column_sort_order = (
+                    [sort_column_index]
+                    + [i for i in range(n_cols) if i != sort_column_index]
+                )
+                if sort_column_index >= n_dims:
+                    # Sorting by a measure: order by its computed numeric value.
+                    converted_measures[sort_column_index - n_dims]["sort_by"] = {
+                        "qSortByNumeric": sort_direction,
+                    }
+                    # Rows where the measure is NULL carry no ranking
+                    # information and would otherwise pollute the top/bottom
+                    # of the result.
+                    suppress_missing = True
+                else:
+                    # Sorting by a dimension: set both numeric and ASCII in
+                    # the same direction. Qlik applies numeric ordering to
+                    # numeric fields and alphabetical ordering to text
+                    # fields, so this single pair covers both without the
+                    # caller having to know the field's type.
+                    converted_dimensions[sort_column_index]["sort_by"] = {
+                        "qSortByNumeric": sort_direction,
+                        "qSortByAscii": sort_direction,
+                        "qSortByExpression": 0,
+                        "qExpression": "",
+                    }
+
             # Create correct hypercube structure
             hypercube_def = {
                 "qDimensions": [
@@ -1250,10 +1452,10 @@ class QlikEngineAPI:
                         "qWidth": n_cols,
                     }
                 ],
-                "qSuppressZero": False,
-                "qSuppressMissing": False,
+                "qSuppressZero": bool(suppress_zero),
+                "qSuppressMissing": suppress_missing,
                 "qMode": "S",
-                "qInterColumnSortOrder": list(range(n_cols)),
+                "qInterColumnSortOrder": inter_column_sort_order,
             }
 
             obj_def = {
@@ -1275,8 +1477,9 @@ class QlikEngineAPI:
                 "CreateSessionObject", [obj_def], handle=app_handle,
                 timeout=self.ws_operation_timeout,
             )
+            timings["create_session_object_seconds"] = round(time.monotonic() - t_step, 3)
             logger.info("create_hypercube: %s done in %.2fs",
-                        step, time.monotonic() - t_step)
+                        step, timings["create_session_object_seconds"])
 
             if "qReturn" not in result or "qHandle" not in result["qReturn"]:
                 return {
@@ -1293,8 +1496,9 @@ class QlikEngineAPI:
             t_step = time.monotonic()
             layout = self.send_request("GetLayout", [], handle=cube_handle,
                                        timeout=self.ws_operation_timeout)
+            timings["get_layout_seconds"] = round(time.monotonic() - t_step, 3)
             logger.info("create_hypercube: %s done in %.2fs",
-                        step, time.monotonic() - t_step)
+                        step, timings["get_layout_seconds"])
 
             if "qLayout" not in layout or "qHyperCube" not in layout["qLayout"]:
                 return {
@@ -1318,31 +1522,79 @@ class QlikEngineAPI:
             # analysis and re-run it.
             truncation_warning: Optional[str] = None
             if total_rows_on_server > rows_fetched:
-                truncation_warning = (
-                    f"TRUNCATED: server has {total_rows_on_server} rows, "
-                    f"returned only {rows_fetched} (max_rows={max_rows}, "
-                    f"HARD_LIMIT={HARD_MAX_ROWS}). "
-                    f"Narrow the query instead of asking for more rows:\n"
-                    f"  - add set-analysis filters inside measures: "
-                    f"{{<[<DimPeriod>]={{<val>}}>}} — substitute real "
-                    f"field and value\n"
-                    f"  - use qSortByExpression for top-N ranking and "
-                    f"set max_rows small (15-50)\n"
-                    f"  - split into multiple focused queries (one per "
-                    f"category/period) rather than a giant dump"
-                )
+                if sort_column_index is not None:
+                    # Already a ranked query: the truncation is intended,
+                    # the caller asked for the top/bottom N of a bigger set.
+                    truncation_warning = (
+                        f"Showing the {rows_fetched} "
+                        f"{'highest' if sort_direction == -1 else 'lowest'} "
+                        f"rows by '{column_names[sort_column_index]}' out of "
+                        f"{total_rows_on_server} total rows on the server. "
+                        f"This is expected for a ranked query — raise `limit` "
+                        f"only if you genuinely need more of the ranking."
+                    )
+                else:
+                    truncation_warning = (
+                        f"TRUNCATED: server has {total_rows_on_server} rows, "
+                        f"returned only {rows_fetched} (limit={max_rows}, "
+                        f"HARD_LIMIT={HARD_MAX_ROWS}), and NO sort was "
+                        f"requested — so these are arbitrary rows, not the "
+                        f"most important ones.\n"
+                        f"  - to rank: pass sort_by=\"<measure label>\" with "
+                        f"sort_order=\"desc\" (top-N) or \"asc\" (bottom-N)\n"
+                        f"  - to narrow: add set-analysis filters inside the "
+                        f"measures, e.g. {{<[<DimPeriod>]={{<val>}}>}}\n"
+                        f"  - to split: run one focused query per category "
+                        f"instead of one giant dump"
+                    )
 
-            return {
-                "hypercube_handle": cube_handle,
-                "hypercube_data": hypercube,
-                "dimensions": converted_dimensions,
-                "measures": converted_measures,
+            # Release the session object — the cube has been fully read into
+            # `hypercube`, and leaving it alive pins its result set in Engine
+            # memory for the rest of the session.
+            step = "DestroySessionObject"
+            try:
+                self.send_request(
+                    "DestroySessionObject", [obj_def["qInfo"]["qId"]],
+                    handle=app_handle, timeout=self.ws_operation_timeout,
+                )
+            except Exception as cleanup_exc:
+                # Never fail a successful query because cleanup failed.
+                logger.warning("create_hypercube: DestroySessionObject failed: %s",
+                               cleanup_exc)
+
+            timings["total_seconds"] = round(time.monotonic() - t0, 3)
+
+            response: Dict[str, Any] = {
+                "columns": column_names,
+                "rows": self._matrix_to_rows(initial_pages, column_names),
                 "total_rows": total_rows_on_server,
                 "returned_rows": rows_fetched,
                 "total_columns": total_cols,
+                "sorted_by": (
+                    column_names[sort_column_index]
+                    if sort_column_index is not None else None
+                ),
+                "sort_order": (
+                    ("desc" if sort_direction == -1 else "asc")
+                    if sort_column_index is not None else None
+                ),
+                "grand_total": [
+                    cell.get("qNum") if cell.get("qNum") != "NaN" else cell.get("qText")
+                    for cell in hypercube.get("qGrandTotalRow", []) or []
+                ],
                 "hard_max_rows": HARD_MAX_ROWS,
                 "truncation_warning": truncation_warning,
+                "timings": timings,
+                "dimensions": converted_dimensions,
+                "measures": converted_measures,
             }
+            if include_raw_layout:
+                # Opt-in: the full qHyperCube (qDimensionInfo, qMeasureInfo,
+                # qDataPages with qElemNumber/qState per cell). Costs several
+                # times more tokens than `rows`, so it is off by default.
+                response["hypercube_handle"] = cube_handle
+                response["hypercube_data"] = hypercube
+            return response
 
         except Exception as e:
             elapsed = time.monotonic() - t0
@@ -1353,9 +1605,18 @@ class QlikEngineAPI:
             if isinstance(e, (_socket.timeout, TimeoutError)):
                 category = "socket_timeout"
                 hint = (
-                    f"WebSocket recv() timed out after ~{self.ws_operation_timeout:.0f}s on step '{step}'. "
-                    f"Increase QLIK_WS_OPERATION_TIMEOUT or simplify the hypercube "
-                    f"(fewer dimensions/measures, smaller max_rows, lighter expressions)."
+                    f"Qlik Engine did not answer within ~{self.ws_operation_timeout:.0f}s "
+                    f"on step '{step}'. Make the query cheaper before making the "
+                    f"timeout longer:\n"
+                    f"  1. Narrow every measure with set analysis, e.g. "
+                    f"Sum({{<[Year]={{2026}}>}}Amount) — this is the single "
+                    f"biggest win on large fact tables.\n"
+                    f"  2. Drop high-cardinality dimensions; rank with "
+                    f"sort_by + a small limit instead of returning every group.\n"
+                    f"  3. Never put an expression in a dimension `field` — it "
+                    f"is evaluated per row of the fact table.\n"
+                    f"  4. Only then raise QLIK_WS_TIMEOUT (currently "
+                    f"{self.ws_operation_timeout:.0f}s)."
                 )
                 # Timeout on recv leaves the socket in an inconsistent state —
                 # invalidate cache so the next call opens a fresh connection.
@@ -1388,6 +1649,7 @@ class QlikEngineAPI:
                 "failed_step": step,
                 "elapsed_seconds": round(elapsed, 2),
                 "ws_operation_timeout": self.ws_operation_timeout,
+                "timings": timings,
                 "hint": hint,
                 "traceback": tb,
                 "details": "Error in create_hypercube method",

--- a/qlik_sense_mcp_server/server.py
+++ b/qlik_sense_mcp_server/server.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import functools
+import inspect
 import json
 import ssl
 import sys
@@ -96,11 +97,36 @@ _init_clients()
 
 # ─── FastMCP server ─────────────────────────────────────────────────────────
 
+_mcp_port = int(os.getenv("MCP_PORT", "8000"))
 mcp = FastMCP(
     "qlik-sense-mcp-server",
     host="127.0.0.1",
-    port=8000,
+    port=_mcp_port,
 )
+
+# Reload-task management talks to QRS endpoints (/qrs/reloadtask,
+# /qrs/executionresult, /qrs/reloadtask/{id}/scriptlog) that require
+# repository-admin rights. A JWT analyst reaches QRS through the virtual
+# proxy as an ordinary user and gets 403s there, so advertising those
+# tools in JWT mode only invites the LLM to burn turns on calls that
+# cannot succeed. They are therefore registered in certificate mode only.
+#
+# When the configuration failed to load at all (`config is None`) every
+# tool stays registered — that path is used by `--help` and the tests,
+# and hiding tools there would just be confusing.
+_CERT_ONLY_TOOLS_ENABLED = config is None or config.auth_mode != AUTH_MODE_JWT
+if not _CERT_ONLY_TOOLS_ENABLED:
+    logger.info(
+        "JWT mode: reload-task tools are not registered (QRS task "
+        "administration requires certificate mode)."
+    )
+
+
+def _cert_only_tool():
+    """Register an MCP tool only when running in certificate mode."""
+    def decorator(fn):
+        return mcp.tool()(fn) if _CERT_ONLY_TOOLS_ENABLED else fn
+    return decorator
 
 
 def _err(msg: str, **extra: Any) -> str:
@@ -120,6 +146,25 @@ def _check() -> Optional[str]:
     return None
 
 
+def _describe_call(sig: Optional[inspect.Signature], args, kwargs) -> Dict[str, Any]:
+    """
+    Reconstruct the arguments a tool was called with, for error replies.
+
+    A bare "timed out after 180s" is useless to the caller: the whole
+    point of the echo is that the LLM can see WHICH query it sent, spot
+    the expensive dimension or the missing set-analysis filter, and
+    retry with something cheaper.
+    """
+    if sig is not None:
+        try:
+            bound = sig.bind_partial(*args, **kwargs)
+            bound.apply_defaults()
+            return dict(bound.arguments)
+        except Exception:
+            pass
+    return {"args": list(args), "kwargs": dict(kwargs)}
+
+
 def _timed(func):
     """
     Decorator for MCP tools: measures wall-clock time and injects
@@ -127,7 +172,16 @@ def _timed(func):
 
     Works with tools that return a JSON string (via _ok / _err).
     If the result is not a JSON dict, wraps it into one.
+
+    Any error reply — raised exception or an `{"error": ...}` payload
+    returned by the tool itself — is annotated with the exact request
+    that produced it (`tool` + `request`).
     """
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):  # pragma: no cover - builtins only
+        sig = None
+
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         t0 = time.monotonic()
@@ -142,9 +196,11 @@ def _timed(func):
                     "error": str(ex) or repr(ex),
                     "error_type": type(ex).__name__,
                     "tool": func.__name__,
+                    "request": _describe_call(sig, args, kwargs),
                 },
                 indent=2,
                 ensure_ascii=False,
+                default=str,
             )
         elapsed = round(time.monotonic() - t0, 3)
         if isinstance(result, str):
@@ -159,7 +215,13 @@ def _timed(func):
             if isinstance(parsed, dict):
                 new_dict = {"tool_call_seconds": elapsed}
                 new_dict.update(parsed)
-                return json.dumps(new_dict, indent=2, ensure_ascii=False)
+                if "error" in new_dict:
+                    # Tools report expected failures (timeout, bad field,
+                    # limit exceeded) as a payload rather than an
+                    # exception — echo the request for those too.
+                    new_dict.setdefault("tool", func.__name__)
+                    new_dict.setdefault("request", _describe_call(sig, args, kwargs))
+                return json.dumps(new_dict, indent=2, ensure_ascii=False, default=str)
             return json.dumps(
                 {"tool_call_seconds": elapsed, "result": parsed},
                 indent=2,
@@ -313,6 +375,12 @@ def get_about() -> str:
 
     Returns:
         JSON with fields: buildVersion, buildDate, databaseProvider, nodeType, sharedPersistence, requiresBootstrap.
+    
+    Example:
+        Call: {}
+        Returns: {"tool_call_seconds": 0.21, "buildVersion": "31.56.2.0",
+                  "buildDate": "10/24/2025 09:43:09 AM", "nodeType": 1,
+                  "sharedPersistence": true, "requiresBootstrap": false}
     """
     e = _check()
     if e:
@@ -348,8 +416,27 @@ def get_apps(
             published apps; `"false"` — unpublished; any other value — both.
 
     Returns:
-        JSON with `apps` (list of {guid, name, stream, description, modifiedDate,
-        lastReloadTime, published, fileSize}) and `pagination` metadata.
+        JSON with `apps` (list of {guid, name, description, stream,
+        modified_dttm, reload_dttm}) and `pagination` metadata.
+    
+    Example (find an app by a fragment of its name):
+        Call: {"name": "Sales", "limit": 5}
+        Returns: {"tool_call_seconds": 0.53,
+                  "apps": [{"guid": "a1b2c3d4-1111-2222-3333-444455556666",
+                            "name": "Sales Dashboard", "description": "...",
+                            "stream": "Finance",
+                            "modified_dttm": "2026-07-20T09:15:00.000Z",
+                            "reload_dttm": "2026-07-27T03:00:00.000Z"}],
+                  "pagination": {"limit": 5, "offset": 0, "returned": 1,
+                                 "total_found": 1, "has_more": false,
+                                 "next_offset": null}}
+
+    Example (next page of all published apps):
+        Call: {"limit": 25, "offset": 25}
+        Returns: {"tool_call_seconds": 0.61, "apps": ["...25 items..."],
+                  "pagination": {"limit": 25, "offset": 25, "returned": 25,
+                                 "total_found": 1102, "has_more": true,
+                                 "next_offset": 50}}
     """
     e = _check()
     if e:
@@ -386,6 +473,28 @@ def get_app_details(app_id: Optional[str] = None, name: Optional[str] = None) ->
         non-system, non-hidden field with its table, is_key flag, distinct_values,
         row count, and tags). Use the `fields` list to check field names and
         cardinalities before writing hypercube dimensions.
+    
+    Example:
+        Call: {"app_id": "a1b2c3d4-1111-2222-3333-444455556666"}
+        Returns: {"tool_call_seconds": 2.84,
+                  "metainfo": {"app_id": "a1b2...", "name": "Sales Dashboard",
+                               "stream": "Finance",
+                               "reload_dttm": "2026-07-27T03:00:00.000Z"},
+                  "warnings": ["Large fact table(s) detected ..."],
+                  "tables": [{"name": "Orders", "fields_count": 12,
+                              "rows": 91028794}],
+                  "fields": [{"name": "Amount", "table": "Orders",
+                              "is_key": false, "distinct_values": 9797173,
+                              "rows": 91028794, "tags": ["$numeric"]}],
+                  "tables_count": 8, "fields_count": 120}
+
+    Read `warnings` first — it tells you which tables are too big to
+    aggregate without a set-analysis filter.
+
+    Qlik session limit: this server keeps ONE Engine session for all
+    calls. Qlik allows max 5 concurrent sessions per user and may LOCK
+    the account beyond that — never run these calls in parallel or
+    start a second MCP process with the same credentials.
     """
     e = _check()
     if e:
@@ -557,6 +666,18 @@ def get_app_script(app_id: str) -> str:
     Returns:
         JSON with `qScript` (the full script as a single string),
         `script_length` (character count), and `app_id`.
+    
+    Example:
+        Call: {"app_id": "a1b2c3d4-1111-2222-3333-444455556666"}
+        Returns: {"tool_call_seconds": 1.12,
+                  "qScript": "SET ThousandSep=' ';\nOrders:\nLOAD ... FROM ...",
+                  "app_id": "a1b2c3d4-1111-2222-3333-444455556666",
+                  "script_length": 14872}
+
+    Qlik session limit: this server keeps ONE Engine session for all
+    calls. Qlik allows max 5 concurrent sessions per user and may LOCK
+    the account beyond that — never run these calls in parallel or
+    start a second MCP process with the same credentials.
     """
     e = _check()
     if e:
@@ -614,6 +735,28 @@ def get_app_field_statistics(
         max_value, null_percentage, completeness_percentage. If `full=True`,
         also avg_value/sum_value/median_value/mode_value/std_deviation. Each
         stat is `{text, numeric, is_numeric}`.
+    
+    Example (default light mode):
+        Call: {"app_id": "a1b2...", "field_name": "Amount"}
+        Returns: {"tool_call_seconds": 3.4, "field_name": "Amount",
+                  "unique_values": {"text": "9421", "numeric": 9421,
+                                    "is_numeric": true},
+                  "total_count": {"...": "..."},
+                  "non_null_count": {"...": "..."},
+                  "min_value": {"...": "..."}, "max_value": {"...": "..."},
+                  "null_percentage": 0.67, "completeness_percentage": 99.33,
+                  "debug_log": ["..."]}
+
+    Example (full mode — adds avg/sum/median/mode/stdev, slow):
+        Call: {"app_id": "a1b2...", "field_name": "Amount", "full": true}
+        Returns: {"tool_call_seconds": 41.7, "avg_value": {"...": "..."},
+                  "sum_value": {"...": "..."}, "median_value": {"...": "..."},
+                  "mode_value": {"...": "..."}, "std_deviation": {"...": "..."}}
+
+    Qlik session limit: this server keeps ONE Engine session for all
+    calls. Qlik allows max 5 concurrent sessions per user and may LOCK
+    the account beyond that — never run these calls in parallel or
+    start a second MCP process with the same credentials.
     """
     e = _check()
     if e:
@@ -655,6 +798,21 @@ def engine_get_field_range(app_id: str, field_name: str) -> str:
     Returns:
         JSON `{ "field_name": ..., "unique_values": {text,numeric},
         "min_value": {text,numeric}, "max_value": {text,numeric} }`.
+    
+    Example:
+        Call: {"app_id": "a1b2...", "field_name": "OrderDate"}
+        Returns: {"tool_call_seconds": 0.9, "field_name": "OrderDate",
+                  "unique_values": {"text": "939", "numeric": 939,
+                                    "is_numeric": true},
+                  "min_value": {"text": "2024-01-01", "numeric": 45292,
+                                "is_numeric": true},
+                  "max_value": {"text": "2026-07-27", "numeric": 46230,
+                                "is_numeric": true}}
+
+    Qlik session limit: this server keeps ONE Engine session for all
+    calls. Qlik allows max 5 concurrent sessions per user and may LOCK
+    the account beyond that — never run these calls in parallel or
+    start a second MCP process with the same credentials.
     """
     e = _check()
     if e:
@@ -672,234 +830,257 @@ def engine_create_hypercube(
     app_id: str,
     dimensions: Optional[List[Dict[str, Any]]] = None,
     measures: Optional[List[Dict[str, Any]]] = None,
-    max_rows: int = DEFAULT_HYPERCUBE_MAX_ROWS,
+    limit: int = DEFAULT_HYPERCUBE_MAX_ROWS,
+    sort_by: Optional[str] = None,
+    sort_order: str = "desc",
+    suppress_zero: bool = False,
+    include_raw_layout: bool = False,
+    max_rows: Optional[int] = None,
 ) -> str:
     """
-    Build a Qlik Engine hypercube (grouped aggregation) and return its rows.
-    This is the MAIN data-analysis tool — use it for anything shaped like a
-    SQL `SELECT ... GROUP BY ... ORDER BY`.
+    Run a grouped aggregation against a Qlik app and return the rows.
+    This is the MAIN data-analysis tool. It is the Qlik equivalent of:
 
-    BEFORE CALLING:
-      1. Call `get_app_details` first to learn the exact field names AND
-         `distinct_values` of every field. Field names are case-sensitive
-         and must match the data model. All examples below use generic
-         placeholders `<DimA>`, `<DimB>`, `<MetricX>` — substitute with
-         the REAL field names from `get_app_details`.
-      2. ESTIMATE THE RESULT SIZE BEFORE SENDING THE REQUEST. Multiply
-         the `distinct_values` of every dimension you plan to include.
-         That product is the MAXIMUM possible row count — if it exceeds
-         5000, you MUST either:
-           (a) narrow the scope via set analysis inside the measures
-               (the dimensions themselves can't be filtered this way —
-               see RULE #2 below), OR
-           (b) drop one of the dimensions, OR
-           (c) switch to a top-N pattern (`max_rows=15` +
-               `qSortByExpression` on the ranking), OR
-           (d) split the problem into N separate hypercubes, each
-               slicing by one value of a categorical dimension.
-         Generic example: dims=[<DimA> (10 distinct), <DimB> (5000
-         distinct)] → worst case 10*5000 = 50,000 rows → TOO BIG.
-         Fix: drop <DimB> or filter it via
-         `Sum({<[<DimB>]={'<val1>'}>}<MetricX>)` on the measure side,
-         or run 10 separate cubes (one per value of <DimA>).
-      3. Read `get_app_script` to understand how calendar / derived
-         fields are built in the specific app — it matters for set
-         analysis. NEVER assume field names from examples.
-      4. Use `get_app_variables` to discover named set-analysis
-         shortcuts already defined in the app (e.g. `$(<varName>)`).
+        SELECT <dimensions>, <measures>
+        FROM <app>
+        GROUP BY <dimensions>
+        ORDER BY <sort_by> <sort_order>
+        LIMIT <limit>
 
-    ────────────────────────────────────────────────────────────────────────
-    RULE #1 — ALWAYS USE SET ANALYSIS, NEVER `If()` INSIDE A MEASURE
-    ────────────────────────────────────────────────────────────────────────
-    `If()` inside an aggregate is a per-row scan of the entire fact table.
-    Set analysis `{<Field={values}>}` is an index lookup on the symbol
-    table BEFORE aggregation. On a huge fact table that's the difference
-    between minutes and milliseconds.
+    `dimensions` are the GROUP BY columns, `measures` are the aggregates,
+    `sort_by` + `sort_order` are the ORDER BY, and `limit` is the LIMIT.
 
-    BAD  (DO NOT USE):
-        Sum(If(<DimYear>=2025, <MetricX>))
-        Count(If(<DimPeriod>='<val1>' and <DimYear>=2025, <KeyField>))
-        Sum(If([<DimCat>]='<val1>', <MetricX>))
-    GOOD:
-        Sum({<[<DimYear>]={2025}>}<MetricX>)
-        Count({<[<DimPeriod>]={'<val1>'}, [<DimYear>]={2025}>}<KeyField>)
-        Sum({<[<DimCat>]={'<val1>'}>}<MetricX>)
+    ────────────────────────────────────────────────────────────────────
+    EXAMPLE 1 — TOP-N (the most common request)
+    ────────────────────────────────────────────────────────────────────
+    "Give me the 10 clients with the highest GGR":
 
-    SET ANALYSIS QUICK REFERENCE (substitute field names and values from
-    the real app — do NOT copy these placeholders verbatim):
-      • Numeric ($integer/$numeric) field: no quotes
-          `{<[<DimNum>]={2025}>}`
-      • Text field: single quotes
-          `{<[<DimText>]={'<val1>','<val2>'}>}`
-      • Wildcard search: double quotes
-          `{<[<DimText>]={"*<substring>*"}>}`
-      • Multiple values (OR): comma list
-          `{<[<DimText>]={'<v1>','<v2>','<v3>'}>}`
-      • Multiple fields (AND): comma in modifier
-          `{<[<DimA>]={1},[<DimB>]={'<v>'}>}`
-      • Reset a filter: empty value
-          `{<[<Dim>]=>}` ignores any current selection on <Dim>
-      • Ignore ALL current selections: prefix with `1`
-          `{1<[<Dim>]={<v>}>}`
-      • Range on numeric/date:
-          `{<[<DimDate>]={">=$(=Num(MonthStart(Today())))"}>}`
-      • Combine sets: union `+`, intersect `*`, exclude `-`
-          `Sum({<[<Dim>]={<v1>}>+<[<Dim>]={<v2>}>}<MetricX>)`
-      • P() = "values that have ever satisfied":
-          `{<[<Key>]=P({<[<Flag>]={1}>}[<Key>])>}`
-      • E() = "values that have NEVER satisfied":
-          `{<[<Key>]=E({<[<Flag>]={1}>}[<Key>])>}`
-      • Period-over-period ratio:
-          `Sum({<[<DimYear>]={<Y2>}>}<MetricX>) /
-           Sum({<[<DimYear>]={<Y1>}>}<MetricX>) - 1`
+        {
+          "app_id": "a1b2c3d4-1111-2222-3333-444455556666",
+          "dimensions": [{"field": "clientid"}],
+          "measures": [{"expression": "Sum(ggr)", "label": "GGR"}],
+          "sort_by": "GGR",
+          "sort_order": "desc",
+          "limit": 10
+        }
 
-    ────────────────────────────────────────────────────────────────────────
-    RULE #2 — NEVER PUT EXPRESSIONS IN `qFieldDefs` (DIMENSION FIELD)
-    ────────────────────────────────────────────────────────────────────────
-    A dimension's `field` parameter must be a PLAIN FIELD NAME from the
-    data model. If you put an `=expression` there, Qlik evaluates it for
-    EVERY ROW of the underlying table (not for distinct values, not
-    cached) — and it won't use any indexes. On a huge fact table this
-    is a guaranteed timeout.
+    Returns (shortened):
 
-    BAD  (DO NOT USE):
-        {"field": "=Date(<DimDate>)"}            # per-row function call
-        {"field": "=Year(<DimDate>)"}            # per-row function call
-        {"field": "=Month(<DimDate>)"}           # per-row function call
-        {"field": "=If(<MetricX>>0,'A','B')"}    # per-row If() call
-    GOOD:
-        {"field": "<DimDate>"}                   # use the raw field
-        {"field": "<DimYear>"}                   # use a pre-built bucket
-        {"field": "<DimMonth>"}                  # if one exists already
+        {
+          "tool_call_seconds": 4.1,
+          "columns": ["clientid", "GGR"],
+          "rows": [["1042", 918450.5], ["8871", 764300.0]],
+          "total_rows": 5417612,
+          "returned_rows": 10,
+          "sorted_by": "GGR",
+          "sort_order": "desc",
+          "grand_total": [95552568044.93],
+          "timings": {"open_app_seconds": 0.01, "get_layout_seconds": 3.9}
+        }
 
-    HOW TO HANDLE A "MISSING" DERIVED FIELD:
-      If the data model has only a raw date dimension but you need
-      monthly buckets, DO NOT compute a derived value in the dimension.
-      Instead:
-        1. Check `get_app_details` first — there's often already a
-           calendar field (month / year / quarter / week / day-of-week).
-           Use it directly. Names vary per app — READ the field list.
-        2. If genuinely missing, just request the raw date as a
-           dimension and aggregate the resulting 30-365 rows yourself
-           on the client side. That's way cheaper than a per-row
-           expression.
+    `total_rows` is how many groups exist on the server; `returned_rows`
+    is how many came back. For a ranked query that difference is normal
+    and expected — you asked for the top 10 of 5.4 million.
 
-    THE ONE EXCEPTION: `qSortByExpression` is fine — it evaluates the
-    expression per GROUP after aggregation, not per row. That's where
-    you put `Sum({<...>}<MetricX>)` for "sort top-N by metric".
+    For the BOTTOM 10 use `"sort_order": "asc"` (add
+    `"suppress_zero": true` to skip groups whose measure is 0).
 
-    ────────────────────────────────────────────────────────────────────────
-    PERFORMANCE TIPS
-    ────────────────────────────────────────────────────────────────────────
-      - High-cardinality dimensions (>1M distinct values) with
-        `qSortByExpression` force the engine to fully materialize and
-        sort the whole set. On large apps this can take minutes. Keep
-        measures simple, prefer `Sum()` over `Aggr()`, and keep
-        `max_rows` small (15-50) when sorting by expression.
-      - `Aggr()` expressions over high-cardinality dimensions are
-        especially expensive — they build an in-memory pivot per group.
-        Avoid if you can.
-      - Always narrow the period with set analysis before aggregating —
-        a small period filter can cut a billion-row scan by orders of
-        magnitude.
-      - Raise the `QLIK_WS_TIMEOUT` environment variable if you get
-        "WebSocket recv() timed out" on legitimately heavy computations.
+    ────────────────────────────────────────────────────────────────────
+    EXAMPLE 2 — a single total, no grouping
+    ────────────────────────────────────────────────────────────────────
+    "What is the total GGR and the loaded date range?":
+
+        {
+          "app_id": "...",
+          "measures": [
+            {"expression": "Sum(ggr)",       "label": "GGR"},
+            {"expression": "Min(OrderDate)", "label": "FirstDate"},
+            {"expression": "Max(OrderDate)", "label": "LastDate"}
+          ],
+          "limit": 1
+        }
+
+    Omit `dimensions` entirely for a grand-total row. This is the fast,
+    correct way to learn an app's loaded period — never use
+    `get_app_field_statistics` on a date field for that.
+
+    ────────────────────────────────────────────────────────────────────
+    EXAMPLE 3 — filtered breakdown (set analysis)
+    ────────────────────────────────────────────────────────────────────
+    "Revenue by region for 2026 only, biggest first":
+
+        {
+          "app_id": "...",
+          "dimensions": [{"field": "Region"}],
+          "measures": [
+            {"expression": "Sum({<[Year]={2026}>}Amount)", "label": "Revenue2026"}
+          ],
+          "sort_by": "Revenue2026",
+          "sort_order": "desc",
+          "limit": 20
+        }
+
+    ────────────────────────────────────────────────────────────────────
+    HOW TO GET IT RIGHT (and fast)
+    ────────────────────────────────────────────────────────────────────
+    1. Call `get_app_details` FIRST. Field names are case-sensitive and
+       must exist in the data model. It also gives you `distinct_values`
+       per field, which tells you how many rows your query can produce.
+
+    2. FILTER INSIDE MEASURES WITH SET ANALYSIS, NEVER WITH `If()`.
+       `If()` scans every row of the fact table; set analysis is an
+       index lookup done before aggregation. On a 100M-row table that is
+       the difference between minutes and milliseconds.
+           BAD:  Sum(If(Year=2026, Amount))
+           GOOD: Sum({<[Year]={2026}>}Amount)
+       Quick reference (substitute real field names and values):
+         numeric field   {<[Year]={2026}>}
+         text field      {<[Region]={'North','South'}>}
+         wildcard        {<[Region]={"*ampton*"}>}
+         two fields AND  {<[Year]={2026},[Region]={'North'}>}
+         ignore filters  {1<[Region]={'North'}>}
+         ever matched    {<[Client]=P({<[Flag]={1}>}[Client])>}
+         never matched   {<[Client]=E({<[Flag]={1}>}[Client])>}
+
+    3. A DIMENSION `field` MUST BE A PLAIN FIELD NAME — never an
+       expression. `{"field": "=Year(OrderDate)"}` is evaluated for
+       every row of the fact table and will time out. If you need
+       monthly buckets, look for an existing calendar field in
+       `get_app_details`; if there is none, group by the raw date and
+       aggregate the handful of returned rows yourself.
+
+    4. To rank by an aggregate, use `sort_by` — do NOT hand-roll
+       `qSortByExpression` in the dimension. `sort_by` orders by the
+       measure column that was already computed, while
+       `qSortByExpression` makes the Engine compute the same aggregate a
+       SECOND time just for ordering (measured: 66s → 286s on a 91M-row
+       table, and it can silently return a wrong order).
+
+    5. If a call is slow, read `timings` in the response. It splits the
+       time into `open_app_seconds` (loading the app into Engine memory —
+       only the first call against an app pays this) and
+       `get_layout_seconds` (the actual computation). A large
+       `get_layout_seconds` means the query itself is too heavy: add set
+       analysis, drop a dimension, or lower `limit`.
+
+       A well-formed query answers in seconds: grouping by a field that
+       lives in the fact table returns in well under a second even on
+       91M rows. Tens of seconds means the grouping field sits on the far
+       side of a large link table — prefer a dimension closer to the
+       facts, or filter the period with set analysis.
+
+    ────────────────────────────────────────────────────────────────────
+    SESSION LIMIT — NEVER RUN THESE CALLS IN PARALLEL
+    ────────────────────────────────────────────────────────────────────
+    Qlik Sense allows a maximum of **5 concurrent sessions per user
+    identity**, and going over that can get the account LOCKED. This is a
+    Qlik platform limit — no MCP setting can raise it.
+
+    This server deliberately funnels every tool call through ONE cached
+    Engine session, so a whole analysis costs exactly one session. Keep
+    it that way:
+      - issue hypercube calls ONE AT A TIME, never fan them out
+        concurrently to "speed things up" — they are serialised over a
+        single WebSocket anyway, so parallelism buys nothing and risks
+        the lockout;
+      - do not start a second MCP process with the same credentials, and
+        do not run two editors against the same token side by side.
+    When a query is slow, make the query cheaper (see point 5) instead of
+    launching more of them.
 
     Args:
-        app_id: Application GUID. Required.
-        dimensions: List of GROUP BY columns. Each element is an object:
-            ```
-            {
-              "field": "<DimFieldName>",          # real field name, no []
-              "sort_by": {                        # OPTIONAL, default ASCII asc
-                "qSortByNumeric": 0,              # -1 desc, 1 asc, 0 disabled
-                "qSortByAscii": 1,                # -1 desc, 1 asc, 0 disabled
-                "qSortByExpression": -1,          # -1 desc, 1 asc, 0 disabled
-                "qExpression": "Sum({<[<DimYear>]={<Y>}>}<MetricX>)"
-                                                   # required if qSortByExpression != 0
-              }
-            }
-            ```
-            Omit the whole list or pass `[]` for a grand-total row only.
-            Use `qSortByExpression` for "top/bottom N by metric" queries.
-        measures: List of aggregate expressions. Each element is an object:
-            ```
-            {
-              "expression": "Sum({<[<DimYear>]={<Y>}>}<MetricX>)",
-                                              # any valid Qlik expression
-              "label": "<display label>",     # OPTIONAL display name
-              "sort_by": { "qSortByNumeric": -1 }  # OPTIONAL, default desc
-            }
-            ```
-            Set analysis (`{<field={value}>}`) is the ONLY correct way
-            to filter inside a measure — NEVER put filters in dimensions.
-            Use Qlik functions: Sum, Count, Avg, Min, Max, Only,
-            FirstSortedValue, RangeSum, etc. Period-over-period:
-            `"Sum({<[<DimYear>]={<Y2>}>}<MetricX>) /
-              Sum({<[<DimYear>]={<Y1>}>}<MetricX>) - 1"`.
-        max_rows: Maximum rows to return. Default 1000. HARD LIMIT: 5000.
-            The server REJECTS requests with `max_rows > 5000` with a
-            `limit_exceeded` error. The server also REJECTS requests
-            whose `columns * max_rows > 9900` with a `cell_cap_exceeded`
-            error (Qlik's own single-page limit is 10000 cells).
-
-            DO NOT try to work around these limits by bumping max_rows.
-            Instead, narrow the query with set analysis. Correct patterns
-            (substitute the placeholders with real field names from
-            `get_app_details`):
-
-              TOP-N: max_rows=15, qSortByExpression=-1 on the ranking dim,
-                qExpression="Sum({<[<DimPeriod>]={<val>}>}<MetricX>)".
-              PERIOD FILTER: put the period inside every measure —
-                Sum({<[<DimYear>]={<Y>},[<DimPeriod>]={'<v>'}>}<MetricX>).
-              SLICE-BY-CATEGORY: run N small hypercubes, one per category
-                value, each filtered via {<[<DimCat>]={'<v>'}>}. Prefer
-                100 focused queries over 1 giant scan — they're faster
-                AND don't timeout.
-              ESTIMATE BEFORE CALLING: multiply `distinct_values` of your
-                dimensions (from `get_app_details`). If the product
-                exceeds 5000, the query is too broad — add more
-                set-analysis filters or switch to top-N.
+        app_id: Application GUID. Required. From `get_apps`.
+        dimensions: GROUP BY columns. Each item is
+            `{"field": "<FieldName>"}` — a real field name, no brackets,
+            no expression. Omit or pass `[]` for a grand-total row.
+            Advanced: an optional `"sort_by"` object per dimension maps
+            straight onto Qlik `qSortCriterias`
+            (`qSortByNumeric` / `qSortByAscii` / `qSortByExpression` +
+            `qExpression`, each -1 desc / 0 off / 1 asc). The top-level
+            `sort_by` argument overrides it and is what you normally want.
+        measures: Aggregate expressions. Each item is
+            `{"expression": "Sum(Amount)", "label": "Revenue"}`. Always
+            give a `label` — it is the column name AND the value you pass
+            to `sort_by`. Any Qlik aggregation works: Sum, Count,
+            Count(DISTINCT ...), Avg, Min, Max, Only, FirstSortedValue,
+            RangeSum.
+        limit: Max rows to return (the SQL LIMIT). Default 1000, hard cap
+            5000. Also capped by `columns * limit <= 9900` (Qlik itself
+            refuses pages over 10000 cells). For ranked queries a small
+            limit (10-50) is both faster and easier to read.
+        sort_by: Name of the column to order by — a measure `label`, a
+            measure expression, or a dimension field name. Case- and
+            bracket-insensitive; a measure wins over a dimension of the
+            same name. Omit to keep Qlik's default order (ascending by
+            the first dimension) — but then a truncated result contains
+            ARBITRARY rows, not the most important ones.
+        sort_order: `"desc"` (default, largest first — top-N) or `"asc"`
+            (smallest first — bottom-N).
+        suppress_zero: Drop rows whose measure is 0. Default False.
+            Useful for `sort_order="asc"`, where zero-valued groups
+            would otherwise fill the entire result.
+        include_raw_layout: Also return the untouched Qlik `qHyperCube`
+            (per-cell `qElemNumber`/`qState`, `qDimensionInfo`,
+            `qMeasureInfo`). Default False, because it costs several
+            times more tokens than `rows` and is rarely needed.
+        max_rows: Deprecated alias for `limit`, kept so older callers
+            keep working. If both are given, `max_rows` wins.
 
     Returns:
         JSON with:
-          - `total_rows`: full result size on the server (could be huge)
-          - `returned_rows`: how many rows are actually in the matrix
-            below (<= `max_rows`, <= 5000 hard cap)
-          - `hard_max_rows`: 5000 — the enforced upper bound
-          - `truncation_warning`: non-null string if `total_rows >
-            returned_rows`. Tells you the result was truncated and
-            instructs how to narrow the query with set analysis. DO NOT
-            ignore this — retry with a narrower set-analysis filter, or
-            switch to a top-N pattern, or slice the query by category.
-          - `total_columns`: number of dim+measure columns
-          - `dimensions` / `measures`: echoed input
-          - `hypercube_data.qDataPages[0].qMatrix`: the actual cells,
-            each as `{qText, qNum, qElemNumber, qState}`. Read values
-            from `qText` (display) or `qNum` (numeric). `"NaN"` means the
-            cell is empty or contains text.
+          - `columns`: column names, in row order.
+          - `rows`: the data as plain arrays of values — numbers stay
+            numbers, text stays text. Read this, not `hypercube_data`.
+          - `total_rows`: how many groups exist on the server.
+          - `returned_rows`: how many rows are in `rows`.
+          - `sorted_by` / `sort_order`: the sort actually applied
+            (`null` when unsorted).
+          - `grand_total`: totals across ALL groups, per measure —
+            correct even when the rows are truncated.
+          - `truncation_warning`: non-null when `total_rows >
+            returned_rows`. For an unsorted query this means the rows are
+            arbitrary — add `sort_by` or narrow the query.
+          - `timings`: seconds per step (see point 5 above).
 
-    ON ERROR: the response contains `error`, `error_category`, and
-    `hint`. Relevant categories:
-      - `limit_exceeded`: you asked for max_rows > 5000. Redesign the
-        query.
-      - `cell_cap_exceeded`: columns * max_rows > 9900. Either drop
-        columns or reduce max_rows (the hint gives you the exact
-        suggested max_rows).
-      - `socket_timeout`: Qlik is actually computing something slow.
-        Add more set-analysis filters, reduce max_rows, or switch to
-        top-N with qSortByExpression.
-      - `engine_api_error`: invalid expression / unknown field.
+    Errors return `error`, `error_category` and an actionable `hint`:
+        `invalid_sort` — `sort_by` matched no column; the response lists
+            `available_columns`.
+        `limit_exceeded` — limit above 5000.
+        `cell_cap_exceeded` — columns * limit above 9900; the hint gives
+            a concrete smaller limit.
+        `socket_timeout` — the query is genuinely too heavy; the hint
+            lists what to cut, in order of impact.
+        `engine_api_error` — bad expression or unknown field name.
     """
     import traceback as _tb
     e = _check()
     if e:
         return e
+    # `max_rows` is the pre-1.6 name for `limit`. Honour it when supplied
+    # so existing callers and saved prompts keep working unchanged.
+    effective_limit = max_rows if max_rows is not None else limit
     stage = "ensure_app"
+    t_open = time.monotonic()
     try:
         app_handle = engine_api.ensure_app(app_id, no_data=False)
+        open_app_seconds = round(time.monotonic() - t_open, 3)
         stage = "create_hypercube"
-        return _ok(engine_api.create_hypercube(app_handle, dimensions or [], measures or [], max_rows))
+        result = engine_api.create_hypercube(
+            app_handle,
+            dimensions or [],
+            measures or [],
+            effective_limit,
+            sort_by=sort_by,
+            sort_order=sort_order,
+            suppress_zero=suppress_zero,
+            include_raw_layout=include_raw_layout,
+        )
+        # Opening the app dominates the first call against a cold app, so
+        # report it next to the query time instead of hiding it in the
+        # total — otherwise a fast query looks slow.
+        if isinstance(result, dict) and isinstance(result.get("timings"), dict):
+            result["timings"]["open_app_seconds"] = open_app_seconds
+        return _ok(result)
     except Exception as ex:
         logger.exception("engine_create_hypercube failed at stage=%s", stage)
         return _err(
@@ -961,6 +1142,24 @@ def get_app_field(
         JSON `{ "field_values": ["val1", "val2", ...] }` — plain list after
         filtering and pagination. Order is by frequency descending on the
         Qlik side.
+    
+    Example (see what values a dimension holds):
+        Call: {"app_id": "a1b2...", "field_name": "Region", "limit": 5}
+        Returns: {"tool_call_seconds": 0.7,
+                  "field_values": ["North", "South", "West"]}
+
+    Example (wildcard search; `fallback_used` appears when the fast
+    ListObject path returned nothing and a hypercube was used instead):
+        Call: {"app_id": "a1b2...", "field_name": "OrderID",
+               "search_string": "ORD-2026*", "limit": 10}
+        Returns: {"tool_call_seconds": 2.1,
+                  "field_values": ["ORD-2026-000001"],
+                  "fallback_used": "hypercube"}
+
+    Qlik session limit: this server keeps ONE Engine session for all
+    calls. Qlik allows max 5 concurrent sessions per user and may LOCK
+    the account beyond that — never run these calls in parallel or
+    start a second MCP process with the same credentials.
     """
     e = _check()
     if e:
@@ -1031,6 +1230,23 @@ def get_app_variables(
     Returns:
         JSON `{ "variables_from_script": {name: value, ...}, "variables_from_ui":
         {name: value, ...} }`. Empty group becomes `""` instead of `{}`.
+    
+    Example (default — returns ONLY UI-created variables):
+        Call: {"app_id": "a1b2..."}
+        Returns: {"tool_call_seconds": 0.8, "variables_from_script": "",
+                  "variables_from_ui": {"vSelectedRegion": "North"}}
+
+    Example (script SET/LET variables — you MUST pass "true"):
+        Call: {"app_id": "a1b2...", "created_in_script": "true", "limit": 50}
+        Returns: {"tool_call_seconds": 0.85,
+                  "variables_from_script": {"vCurrentYear": "2026",
+                      "vSetPeriod": "{<[Year]={2026}>}"},
+                  "variables_from_ui": ""}
+
+    Qlik session limit: this server keeps ONE Engine session for all
+    calls. Qlik allows max 5 concurrent sessions per user and may LOCK
+    the account beyond that — never run these calls in parallel or
+    start a second MCP process with the same credentials.
     """
     e = _check()
     if e:
@@ -1077,6 +1293,18 @@ def get_app_sheets(app_id: str) -> str:
         JSON `{ "app_id": ..., "total_sheets": N, "sheets": [{sheet_id, title,
         description}, ...] }`. Pass `sheet_id` into `get_app_sheet_objects` to
         list the charts/tables on that sheet.
+    
+    Example:
+        Call: {"app_id": "a1b2..."}
+        Returns: {"tool_call_seconds": 1.3, "app_id": "a1b2...",
+                  "total_sheets": 2,
+                  "sheets": [{"sheet_id": "b2c3d4e5-1111-...",
+                              "title": "Overview", "description": "..."}]}
+
+    Qlik session limit: this server keeps ONE Engine session for all
+    calls. Qlik allows max 5 concurrent sessions per user and may LOCK
+    the account beyond that — never run these calls in parallel or
+    start a second MCP process with the same credentials.
     """
     e = _check()
     if e:
@@ -1113,6 +1341,18 @@ def get_app_sheet_objects(app_id: str, sheet_id: str) -> str:
         JSON with `objects` array where each element has `object_id`,
         `object_type` (e.g. `"barchart"`, `"table"`, `"kpi"`, `"listbox"`)
         and `object_description` (title). Use `object_id` in `get_app_object`.
+    
+    Example:
+        Call: {"app_id": "a1b2...", "sheet_id": "b2c3d4e5-1111-..."}
+        Returns: {"tool_call_seconds": 1.1, "total_objects": 2,
+                  "objects": [{"object_id": "AbCdEf",
+                               "object_type": "barchart",
+                               "object_description": "Sales by Region"}]}
+
+    Qlik session limit: this server keeps ONE Engine session for all
+    calls. Qlik allows max 5 concurrent sessions per user and may LOCK
+    the account beyond that — never run these calls in parallel or
+    start a second MCP process with the same credentials.
     """
     e = _check()
     if e:
@@ -1152,6 +1392,23 @@ def get_app_object(app_id: str, object_id: str) -> str:
         JSON with full `qLayout` of the object. Key fields depend on the
         object type — look for `qHyperCube.qDimensionInfo`, `qMeasureInfo`,
         `qDataPages[0].qMatrix` for charts/tables.
+    
+    Example:
+        Call: {"app_id": "a1b2...", "object_id": "AbCdEf"}
+        Returns: {"tool_call_seconds": 1.4,
+                  "qLayout": {"qInfo": {"qId": "AbCdEf", "qType": "barchart"},
+                              "qMeta": {"title": "Sales by Region"},
+                              "qHyperCube": {"qDimensionInfo": ["..."],
+                                             "qMeasureInfo": ["..."],
+                                             "qDataPages": ["..."]}}}
+
+    Use this to copy an existing chart's expressions into
+    `engine_create_hypercube`.
+
+    Qlik session limit: this server keeps ONE Engine session for all
+    calls. Qlik allows max 5 concurrent sessions per user and may LOCK
+    the account beyond that — never run these calls in parallel or
+    start a second MCP process with the same credentials.
     """
     e = _check()
     if e:
@@ -1175,7 +1432,7 @@ def get_app_object(app_id: str, object_id: str) -> str:
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool()
+@_cert_only_tool()
 @_timed
 def get_tasks(
     status_filter: Optional[str] = None,
@@ -1205,6 +1462,23 @@ def get_tasks(
         JSON `{ "tasks": [...], "count": N }`. Each task has id, name,
         app_name, enabled, last_execution_result (status, start_time,
         stop_time, details).
+    
+    Example (everything that is currently broken — fastest path):
+        Call: {"status_filter": "failed"}
+        Returns: {"tool_call_seconds": 0.9, "count": 1,
+                  "tasks": [{"id": "c3d4e5f6-1111-...",
+                             "name": "Reload Sales Dashboard",
+                             "app_name": "Sales Dashboard", "enabled": true,
+                             "last_execution_result": {"status": 8,
+                                 "start_time": "2026-07-28T03:00:00.000Z",
+                                 "stop_time": "2026-07-28T03:04:12.000Z",
+                                 "details": ["..."]}}]}
+
+    Example (wildcard filter on the task name):
+        Call: {"name_filter": "Daily*"}
+        Returns: {"tool_call_seconds": 1.2, "tasks": ["..."], "count": 3}
+
+    QRS status codes: 7 = finished OK, 8 = failed.
     """
     e = _check()
     if e:
@@ -1224,7 +1498,7 @@ def get_tasks(
     return _ok({"tasks": tasks, "count": len(tasks)})
 
 
-@mcp.tool()
+@_cert_only_tool()
 @_timed
 def get_task_details(task_id: str) -> str:
     """
@@ -1237,6 +1511,15 @@ def get_task_details(task_id: str) -> str:
     Returns:
         Raw QRS JSON for `/qrs/reloadtask/{id}` — includes enabled, maxRetries,
         taskSessionTimeout, preloadNodes, app reference, tags, privileges, etc.
+    
+    Example:
+        Call: {"task_id": "c3d4e5f6-1111-2222-3333-444455556666"}
+        Returns: {"tool_call_seconds": 0.4, "id": "c3d4e5f6-1111-...",
+                  "name": "Reload Sales Dashboard", "taskType": 0,
+                  "enabled": true, "taskSessionTimeout": 1440,
+                  "maxRetries": 0,
+                  "app": {"id": "a1b2...", "name": "Sales Dashboard"},
+                  "schemaPath": "ReloadTask"}
     """
     e = _check()
     if e:
@@ -1244,7 +1527,7 @@ def get_task_details(task_id: str) -> str:
     return _ok(repo_api.get_reload_task_by_id(task_id))
 
 
-@mcp.tool()
+@_cert_only_tool()
 @_timed
 def start_task(task_id: str) -> str:
     """
@@ -1260,6 +1543,13 @@ def start_task(task_id: str) -> str:
 
     Returns:
         QRS response to `/qrs/task/{id}/start`.
+    
+    Example (WRITE operation — confirm with the user before calling):
+        Call: {"task_id": "c3d4e5f6-1111-2222-3333-444455556666"}
+        Returns: {"tool_call_seconds": 0.35, "raw_response": ""}
+
+    QRS answers 204 No Content, so an empty `raw_response` means the task
+    was queued successfully. Poll `get_task_executions` for progress.
     """
     e = _check()
     if e:
@@ -1267,7 +1557,7 @@ def start_task(task_id: str) -> str:
     return _ok(repo_api.start_task(task_id))
 
 
-@mcp.tool()
+@_cert_only_tool()
 @_timed
 def create_task(app_id: str, task_name: str, enabled: bool = True) -> str:
     """
@@ -1284,6 +1574,15 @@ def create_task(app_id: str, task_name: str, enabled: bool = True) -> str:
 
     Returns:
         Created QRS task object, including the new task `id`.
+    
+    Example (WRITE operation — confirm with the user before calling):
+        Call: {"app_id": "a1b2...", "task_name": "Reload Sales (nightly)",
+               "enabled": true}
+        Returns: {"tool_call_seconds": 0.6, "id": "c3d4e5f6-1111-...",
+                  "name": "Reload Sales (nightly)", "enabled": true,
+                  "app": {"id": "a1b2..."}}
+
+    The new task has NO schedule — attach one with `create_task_schedule`.
     """
     e = _check()
     if e:
@@ -1291,7 +1590,7 @@ def create_task(app_id: str, task_name: str, enabled: bool = True) -> str:
     return _ok(repo_api.create_reload_task(app_id, task_name, enabled))
 
 
-@mcp.tool()
+@_cert_only_tool()
 @_timed
 def update_task(task_id: str, name: Optional[str] = None, enabled: Optional[bool] = None) -> str:
     """
@@ -1304,6 +1603,12 @@ def update_task(task_id: str, name: Optional[str] = None, enabled: Optional[bool
 
     Returns:
         Updated QRS task object.
+    
+    Example (WRITE operation — confirm with the user before calling):
+        Call: {"task_id": "c3d4e5f6-1111-...", "enabled": false}
+        Returns: {"tool_call_seconds": 0.7, "id": "c3d4e5f6-1111-...",
+                  "name": "Reload Sales Dashboard", "enabled": false,
+                  "modifiedDate": "2026-07-28T10:00:00.000Z"}
     """
     e = _check()
     if e:
@@ -1316,7 +1621,7 @@ def update_task(task_id: str, name: Optional[str] = None, enabled: Optional[bool
     return _ok(repo_api.update_reload_task(task_id, updates))
 
 
-@mcp.tool()
+@_cert_only_tool()
 @_timed
 def delete_task(task_id: str) -> str:
     """
@@ -1328,6 +1633,10 @@ def delete_task(task_id: str) -> str:
 
     Returns:
         QRS delete response.
+    
+    Example (DESTRUCTIVE — never call without explicit user confirmation):
+        Call: {"task_id": "c3d4e5f6-1111-2222-3333-444455556666"}
+        Returns: {"tool_call_seconds": 0.4, "raw_response": ""}
     """
     e = _check()
     if e:
@@ -1335,7 +1644,7 @@ def delete_task(task_id: str) -> str:
     return _ok(repo_api.delete_reload_task(task_id))
 
 
-@mcp.tool()
+@_cert_only_tool()
 @_timed
 def get_task_schedule(task_id: str) -> str:
     """
@@ -1348,6 +1657,16 @@ def get_task_schedule(task_id: str) -> str:
         JSON `{ "task_id": ..., "triggers": [...], "count": N }`. Each trigger
         describes its repetition rule (daily/hourly/etc.), start time, time
         zone, and enabled state.
+    
+    Example:
+        Call: {"task_id": "c3d4e5f6-1111-2222-3333-444455556666"}
+        Returns: {"tool_call_seconds": 0.5, "task_id": "c3d4e5f6-1111-...",
+                  "count": 1,
+                  "triggers": [{"id": "e5f6a7b8-1111-...",
+                                "name": "Nightly 03:00", "enabled": true,
+                                "timeZone": "Europe/Moscow",
+                                "startDate": "2026-04-01T00:00:00.000Z",
+                                "incrementDescription": "0 0 1440 0"}]}
     """
     e = _check()
     if e:
@@ -1356,7 +1675,7 @@ def get_task_schedule(task_id: str) -> str:
     return _ok({"task_id": task_id, "triggers": triggers, "count": len(triggers)})
 
 
-@mcp.tool()
+@_cert_only_tool()
 @_timed
 def create_task_schedule(
     task_id: str,
@@ -1387,6 +1706,16 @@ def create_task_schedule(
 
     Returns:
         QRS response with the created schema event/trigger object.
+    
+    Example (WRITE operation — confirm with the user; always set
+    start_date to a real future time instead of keeping the default):
+        Call: {"task_id": "c3d4e5f6-1111-...", "name": "Nightly 03:00",
+               "repeat": "daily", "interval_minutes": 1440,
+               "start_date": "2026-08-01T03:00:00.000Z",
+               "time_zone": "Europe/Moscow", "enabled": true}
+        Returns: {"tool_call_seconds": 0.6, "id": "e5f6a7b8-1111-...",
+                  "name": "Nightly 03:00", "enabled": true,
+                  "startDate": "2026-08-01T03:00:00.000Z"}
     """
     e = _check()
     if e:
@@ -1396,7 +1725,7 @@ def create_task_schedule(
     return _ok(repo_api.create_schema_trigger(task_id, name, time_zone, start_date, repeat_opt, interval_minutes, enabled))
 
 
-@mcp.tool()
+@_cert_only_tool()
 @_timed
 def get_task_executions(task_id: str, top: int = 10) -> str:
     """
@@ -1410,9 +1739,20 @@ def get_task_executions(task_id: str, top: int = 10) -> str:
         top: How many most-recent executions to return. Default 10.
 
     Returns:
-        JSON `{ "task_id": ..., "executions": [...], "count": N }`. Each
-        entry: status, start_time, stop_time, duration, details (script log
-        tail on failure), execution_host.
+        JSON `{ "task_id": ..., "executions": [...], "count": N }`. Entries
+        are raw QRS objects in camelCase: status (7 = OK, 8 = failed),
+        startTime, stopTime, duration (MILLISECONDS), executingNodeName,
+        scriptLogAvailable, details.
+    
+    Example (raw QRS objects, newest first — note the camelCase keys and
+    that `duration` is in MILLISECONDS):
+        Call: {"task_id": "c3d4e5f6-1111-...", "top": 2}
+        Returns: {"tool_call_seconds": 0.6, "count": 2,
+                  "executions": [{"id": "d4e5f6a7-1111-...", "status": 7,
+                      "startTime": "2026-07-28T03:00:00.000Z",
+                      "stopTime": "2026-07-28T03:04:12.000Z",
+                      "duration": 252000, "executingNodeName": "Central",
+                      "scriptLogAvailable": true, "details": ["..."]}]}
     """
     e = _check()
     if e:
@@ -1421,7 +1761,7 @@ def get_task_executions(task_id: str, top: int = 10) -> str:
     return _ok({"task_id": task_id, "executions": results, "count": len(results)})
 
 
-@mcp.tool()
+@_cert_only_tool()
 @_timed
 def get_task_script_log(task_id: str) -> str:
     """
@@ -1437,6 +1777,12 @@ def get_task_script_log(task_id: str) -> str:
 
     Returns:
         Raw log text (not JSON).
+    
+    Example (returns PLAIN TEXT, not JSON — it arrives wrapped in the
+    "result" key and can be several MB):
+        Call: {"task_id": "c3d4e5f6-1111-2222-3333-444455556666"}
+        Returns: {"tool_call_seconds": 1.85,
+                  "result": "2026-07-28 03:00:01 Execution started.\n..."}
     """
     e = _check()
     if e:
@@ -1445,7 +1791,7 @@ def get_task_script_log(task_id: str) -> str:
     return log_text
 
 
-@mcp.tool()
+@_cert_only_tool()
 @_timed
 def get_failed_tasks_with_logs() -> str:
     """
@@ -1460,6 +1806,17 @@ def get_failed_tasks_with_logs() -> str:
     Returns:
         JSON `{ "failed_tasks": [{task_id, task_name, app_name, last_start,
         last_stop, details, log_tail}, ...], "count": N }`.
+    
+    Example:
+        Call: {}
+        Returns: {"tool_call_seconds": 4.2, "count": 1,
+                  "failed_tasks": [{"task_id": "c3d4e5f6-1111-...",
+                      "task_name": "Reload Sales Dashboard",
+                      "app_name": "Sales Dashboard",
+                      "last_start": "2026-07-28T03:00:00.000Z",
+                      "last_stop": "2026-07-28T03:04:12.000Z",
+                      "details": ["..."],
+                      "log_tail": "...Error: Field 'AmountX' not found..."}]}
     """
     e = _check()
     if e:
@@ -1484,7 +1841,7 @@ def get_failed_tasks_with_logs() -> str:
     return _ok({"failed_tasks": results, "count": len(results)})
 
 
-@mcp.tool()
+@_cert_only_tool()
 @_timed
 def get_task_dependencies(task_id: str, direction: str = "downstream") -> str:
     """
@@ -1507,6 +1864,25 @@ def get_task_dependencies(task_id: str, direction: str = "downstream") -> str:
     Returns:
         JSON `{ "root_task_id": ..., "direction": ..., "dependencies":
         [{id, name, depth}, ...], "count": N }`.
+    
+    Example (downstream — what runs after this task succeeds):
+        Call: {"task_id": "c3d4e5f6-1111-..."}
+        Returns: {"tool_call_seconds": 1.0,
+                  "root_task_id": "c3d4e5f6-1111-...",
+                  "direction": "downstream", "count": 2,
+                  "dependencies": [{"id": "c3d4...67",
+                                    "name": "Reload Finance Mart",
+                                    "depth": 1},
+                                   {"id": "c3d4...68",
+                                    "name": "Reload Finance Dashboard",
+                                    "depth": 2}]}
+
+    Example (upstream — what must finish before this task can start):
+        Call: {"task_id": "c3d4...68", "direction": "upstream"}
+        Returns: {"tool_call_seconds": 1.0, "direction": "upstream",
+                  "dependencies": [{"id": "c3d4...67",
+                                    "name": "Reload Finance Mart",
+                                    "depth": 1}], "count": 1}
     """
     e = _check()
     if e:
@@ -1560,7 +1936,7 @@ def get_task_dependencies(task_id: str, direction: str = "downstream") -> str:
 
 async def async_main():
     """Async main entry point — runs streamable HTTP transport."""
-    logger.info("Starting qlik-sense-mcp-server v%s (streamable-http on :8000/mcp)", __version__)
+    logger.info("Starting qlik-sense-mcp-server v%s (streamable-http on :%d/mcp)", __version__, _mcp_port)
     await mcp.run_streamable_http_async()
 
 
@@ -1595,14 +1971,17 @@ USAGE:
     qlik-sense-mcp-server --help       Show this help
     qlik-sense-mcp-server --version    Show version
 
-TOOLS ({len(mcp._tool_manager._tools)} total):
+TOOLS ({len(mcp._tool_manager._tools)} registered in the current auth mode):
     Repository: get_about, get_apps, get_app_details
-    Engine:     get_app_script, get_app_field_statistics, engine_create_hypercube,
-                get_app_field, get_app_variables, get_app_sheets,
-                get_app_sheet_objects, get_app_object
-    Tasks:      get_tasks, get_task_details, start_task, create_task, update_task,
-                delete_task, get_task_schedule, create_task_schedule,
-                get_task_executions, get_task_script_log, get_failed_tasks_with_logs
+    Engine:     get_app_script, get_app_field_statistics, engine_get_field_range,
+                engine_create_hypercube, get_app_field, get_app_variables,
+                get_app_sheets, get_app_sheet_objects, get_app_object
+    Tasks:      get_tasks, get_task_details, get_task_dependencies, start_task,
+                create_task, update_task, delete_task, get_task_schedule,
+                create_task_schedule, get_task_executions, get_task_script_log,
+                get_failed_tasks_with_logs
+                (certificate mode only — QRS task administration is not
+                 available to a JWT analyst identity)
 
 GitHub: https://github.com/bintocher/qlik-sense-mcp
 """)

--- a/tests/test_hypercube.py
+++ b/tests/test_hypercube.py
@@ -1,0 +1,252 @@
+"""Tests for hypercube sorting, limits and the request echo (since v1.6.0)."""
+
+import json
+
+import pytest
+
+from qlik_sense_mcp_server.engine_api import QlikEngineAPI
+from qlik_sense_mcp_server import server as srv
+
+
+DIMS = [{"field": "clientid"}]
+MEASURES = [{"expression": "Sum(ggr)", "label": "GGR"}]
+
+
+class TestSortOrderNormalisation:
+    @pytest.mark.parametrize("value", ["desc", "DESC", " Descending ", "top", -1, "-1"])
+    def test_descending_aliases(self, value):
+        assert QlikEngineAPI._normalize_sort_order(value) == -1
+
+    @pytest.mark.parametrize("value", ["asc", "ASCENDING", "bottom", 1, "1"])
+    def test_ascending_aliases(self, value):
+        assert QlikEngineAPI._normalize_sort_order(value) == 1
+
+    @pytest.mark.parametrize("value", ["sideways", "", None, 5, True, False, 0])
+    def test_rejects_unknown(self, value):
+        assert QlikEngineAPI._normalize_sort_order(value) is None
+
+
+class TestColumnResolution:
+    def test_columns_are_dimensions_then_measures(self):
+        names = QlikEngineAPI._column_names(DIMS, MEASURES)
+        assert names == ["clientid", "GGR"]
+
+    def test_measure_label_resolves_to_measure_column(self):
+        assert QlikEngineAPI._resolve_sort_column("GGR", DIMS, MEASURES) == 1
+
+    def test_measure_expression_resolves(self):
+        assert QlikEngineAPI._resolve_sort_column("Sum(ggr)", DIMS, MEASURES) == 1
+
+    def test_dimension_field_resolves(self):
+        assert QlikEngineAPI._resolve_sort_column("clientid", DIMS, MEASURES) == 0
+
+    def test_matching_ignores_case_and_brackets(self):
+        assert QlikEngineAPI._resolve_sort_column("[ggr]", DIMS, MEASURES) == 1
+        assert QlikEngineAPI._resolve_sort_column("CLIENTID", DIMS, MEASURES) == 0
+
+    def test_measure_wins_over_same_named_dimension(self):
+        dims = [{"field": "Amount"}]
+        measures = [{"expression": "Sum(Amount)", "label": "Amount"}]
+        assert QlikEngineAPI._resolve_sort_column("Amount", dims, measures) == 1
+
+    def test_auto_generated_measure_name(self):
+        measures = [{"expression": "Sum(x)"}]
+        assert QlikEngineAPI._resolve_sort_column("Measure_0", DIMS, measures) == 1
+
+    def test_integer_index_passthrough_and_bounds(self):
+        assert QlikEngineAPI._resolve_sort_column(1, DIMS, MEASURES) == 1
+        assert QlikEngineAPI._resolve_sort_column(9, DIMS, MEASURES) is None
+
+    def test_unknown_name(self):
+        assert QlikEngineAPI._resolve_sort_column("Revenue", DIMS, MEASURES) is None
+
+
+class TestMatrixToRows:
+    def test_numbers_stay_numbers_and_nan_falls_back_to_text(self):
+        pages = [{"qMatrix": [
+            [{"qText": "North", "qNum": "NaN"}, {"qText": "1 250", "qNum": 1250.0}],
+            [{"qText": "South", "qNum": "NaN"}, {"qText": "800", "qNum": 800.0}],
+        ]}]
+        rows = QlikEngineAPI._matrix_to_rows(pages, ["Region", "Sales"])
+        assert rows == [["North", 1250.0], ["South", 800.0]]
+
+    def test_handles_empty_pages(self):
+        assert QlikEngineAPI._matrix_to_rows([], ["a"]) == []
+        assert QlikEngineAPI._matrix_to_rows(None, ["a"]) == []
+
+
+class _FakeEngine(QlikEngineAPI):
+    """Captures the hypercube definition without touching the network."""
+
+    def __init__(self):
+        self.sent = []
+        self.ws_operation_timeout = 30.0
+        self.ws_timeout_seconds = 30.0
+
+    def send_request(self, method, params=None, handle=-1, timeout=None):
+        self.sent.append((method, params))
+        if method == "CreateSessionObject":
+            return {"qReturn": {"qHandle": 7}}
+        if method == "GetLayout":
+            return {"qLayout": {"qHyperCube": {
+                "qSize": {"qcx": 2, "qcy": 4200},
+                "qDataPages": [{"qMatrix": [
+                    [{"qText": "42", "qNum": 42.0}, {"qText": "999", "qNum": 999.0}],
+                ]}],
+                "qGrandTotalRow": [{"qText": "1000", "qNum": 1000.0}],
+            }}}
+        return {}
+
+    @property
+    def cube_def(self):
+        for method, params in self.sent:
+            if method == "CreateSessionObject":
+                return params[0]["qHyperCubeDef"]
+        raise AssertionError("CreateSessionObject was never sent")
+
+
+class TestHypercubeDefinition:
+    def test_sorting_by_measure_puts_measure_column_first(self):
+        eng = _FakeEngine()
+        eng.create_hypercube(1, DIMS, MEASURES, 10, sort_by="GGR", sort_order="desc")
+        cube = eng.cube_def
+        # The whole point: measure column (index 1) leads the sort order.
+        assert cube["qInterColumnSortOrder"] == [1, 0]
+        assert cube["qMeasures"][0]["qSortBy"] == {"qSortByNumeric": -1}
+
+    def test_ascending_flips_only_the_direction(self):
+        eng = _FakeEngine()
+        eng.create_hypercube(1, DIMS, MEASURES, 10, sort_by="GGR", sort_order="asc")
+        assert eng.cube_def["qInterColumnSortOrder"] == [1, 0]
+        assert eng.cube_def["qMeasures"][0]["qSortBy"] == {"qSortByNumeric": 1}
+
+    def test_sorting_by_dimension_sets_both_numeric_and_ascii(self):
+        eng = _FakeEngine()
+        eng.create_hypercube(1, DIMS, MEASURES, 10, sort_by="clientid", sort_order="asc")
+        cube = eng.cube_def
+        assert cube["qInterColumnSortOrder"] == [0, 1]
+        criteria = cube["qDimensions"][0]["qDef"]["qSortCriterias"][0]
+        assert criteria["qSortByNumeric"] == 1
+        assert criteria["qSortByAscii"] == 1
+
+    def test_without_sort_by_the_legacy_order_is_preserved(self):
+        eng = _FakeEngine()
+        eng.create_hypercube(1, DIMS, MEASURES, 10)
+        assert eng.cube_def["qInterColumnSortOrder"] == [0, 1]
+
+    def test_measure_sort_suppresses_missing_rows(self):
+        eng = _FakeEngine()
+        eng.create_hypercube(1, DIMS, MEASURES, 10, sort_by="GGR")
+        assert eng.cube_def["qSuppressMissing"] is True
+
+    def test_suppress_zero_is_opt_in(self):
+        eng = _FakeEngine()
+        eng.create_hypercube(1, DIMS, MEASURES, 10, suppress_zero=True)
+        assert eng.cube_def["qSuppressZero"] is True
+
+    def test_page_height_follows_limit(self):
+        eng = _FakeEngine()
+        eng.create_hypercube(1, DIMS, MEASURES, 25)
+        assert eng.cube_def["qInitialDataFetch"][0]["qHeight"] == 25
+
+    def test_input_dicts_are_not_mutated(self):
+        eng = _FakeEngine()
+        dims = [{"field": "clientid"}]
+        measures = [{"expression": "Sum(ggr)", "label": "GGR"}]
+        eng.create_hypercube(1, dims, measures, 10, sort_by="GGR")
+        assert dims == [{"field": "clientid"}]
+        assert measures == [{"expression": "Sum(ggr)", "label": "GGR"}]
+
+
+class TestHypercubeResponse:
+    def test_compact_response_shape(self):
+        eng = _FakeEngine()
+        result = eng.create_hypercube(1, DIMS, MEASURES, 10, sort_by="GGR")
+        assert result["columns"] == ["clientid", "GGR"]
+        assert result["rows"] == [[42.0, 999.0]]
+        assert result["sorted_by"] == "GGR"
+        assert result["sort_order"] == "desc"
+        assert result["grand_total"] == [1000.0]
+        assert "timings" in result
+        # Raw layout is opt-in — it costs several times more tokens.
+        assert "hypercube_data" not in result
+
+    def test_raw_layout_opt_in(self):
+        eng = _FakeEngine()
+        result = eng.create_hypercube(1, DIMS, MEASURES, 10, include_raw_layout=True)
+        assert "hypercube_data" in result
+        assert result["hypercube_handle"] == 7
+
+    def test_session_object_is_destroyed(self):
+        eng = _FakeEngine()
+        eng.create_hypercube(1, DIMS, MEASURES, 10)
+        assert any(m == "DestroySessionObject" for m, _ in eng.sent)
+
+    def test_ranked_truncation_warning_explains_it_is_expected(self):
+        eng = _FakeEngine()
+        result = eng.create_hypercube(1, DIMS, MEASURES, 10, sort_by="GGR")
+        assert "highest" in result["truncation_warning"]
+
+    def test_unsorted_truncation_warning_flags_arbitrary_rows(self):
+        eng = _FakeEngine()
+        result = eng.create_hypercube(1, DIMS, MEASURES, 10)
+        assert "NO sort was requested" in result["truncation_warning"]
+
+
+class TestHypercubeGuardRails:
+    def test_unknown_sort_column_lists_available_columns(self):
+        eng = _FakeEngine()
+        result = eng.create_hypercube(1, DIMS, MEASURES, 10, sort_by="Revenue")
+        assert result["error_category"] == "invalid_sort"
+        assert result["available_columns"] == ["clientid", "GGR"]
+        assert not eng.sent, "must fail before touching the Engine"
+
+    def test_bad_sort_order_is_rejected(self):
+        eng = _FakeEngine()
+        result = eng.create_hypercube(1, DIMS, MEASURES, 10, sort_by="GGR",
+                                      sort_order="sideways")
+        assert result["error_category"] == "invalid_sort"
+
+    def test_limit_above_hard_cap(self):
+        eng = _FakeEngine()
+        result = eng.create_hypercube(1, DIMS, MEASURES, 5001)
+        assert result["error_category"] == "limit_exceeded"
+
+    def test_cell_cap(self):
+        eng = _FakeEngine()
+        measures = [{"expression": f"Sum(f{i})", "label": f"M{i}"} for i in range(9)]
+        result = eng.create_hypercube(1, DIMS, measures, 1000)
+        assert result["error_category"] == "cell_cap_exceeded"
+        assert result["hint"]
+
+
+class TestRequestEcho:
+    """A timeout must say WHICH query timed out, not just that it did."""
+
+    def test_exception_reply_echoes_the_request(self):
+        @srv._timed
+        def boom(app_id: str, limit: int = 10):
+            raise TimeoutError("WebSocket recv() timed out after 180.0s")
+
+        parsed = json.loads(boom("app-1", limit=99))
+        assert parsed["error_type"] == "TimeoutError"
+        assert parsed["tool"] == "boom"
+        assert parsed["request"] == {"app_id": "app-1", "limit": 99}
+
+    def test_error_payload_reply_echoes_the_request(self):
+        @srv._timed
+        def failing(app_id: str, sort_by: str = None):
+            return json.dumps({"error": "boom", "error_category": "socket_timeout"})
+
+        parsed = json.loads(failing("app-2", sort_by="GGR"))
+        assert parsed["request"] == {"app_id": "app-2", "sort_by": "GGR"}
+        assert parsed["tool"] == "failing"
+
+    def test_successful_reply_has_no_echo(self):
+        @srv._timed
+        def fine(app_id: str):
+            return json.dumps({"rows": []})
+
+        parsed = json.loads(fine("app-3"))
+        assert "request" not in parsed
+        assert "tool_call_seconds" in parsed

--- a/tests/test_tool_registration.py
+++ b/tests/test_tool_registration.py
@@ -1,0 +1,76 @@
+"""Tool visibility per authentication mode (since v1.6.0).
+
+Reload-task tools hit QRS endpoints that need repository-admin rights, so
+they are registered in certificate mode only. Advertising them to a JWT
+analyst just invites calls that can only ever return 403.
+"""
+
+import importlib
+
+import pytest
+
+from qlik_sense_mcp_server import server as srv
+
+
+CERT_ONLY_TOOLS = {
+    "get_tasks", "get_task_details", "start_task", "create_task",
+    "update_task", "delete_task", "get_task_schedule",
+    "create_task_schedule", "get_task_executions", "get_task_script_log",
+    "get_failed_tasks_with_logs", "get_task_dependencies",
+}
+
+ALWAYS_AVAILABLE_TOOLS = {
+    "get_about", "get_apps", "get_app_details", "get_app_script",
+    "get_app_field_statistics", "engine_get_field_range", "get_app_field",
+    "get_app_variables", "get_app_sheets", "get_app_sheet_objects",
+    "get_app_object", "engine_create_hypercube",
+}
+
+
+@pytest.fixture
+def reload_server(monkeypatch):
+    """Re-import server.py under a given environment, then restore it."""
+    def _reload(**env):
+        for key in ("QLIK_SERVER_URL", "QLIK_JWT_TOKEN", "QLIK_USER_DIRECTORY",
+                    "QLIK_USER_ID", "QLIK_CLIENT_CERT_PATH", "QLIK_CLIENT_KEY_PATH"):
+            monkeypatch.delenv(key, raising=False)
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+        return importlib.reload(srv)
+
+    yield _reload
+    # Leave the module in its original state for the rest of the suite.
+    monkeypatch.undo()
+    importlib.reload(srv)
+
+
+def test_jwt_mode_hides_reload_task_tools(reload_server):
+    module = reload_server(
+        QLIK_SERVER_URL="https://qlik.example.com/jwt",
+        QLIK_JWT_TOKEN="header.payload.signature",
+    )
+    assert module.config.auth_mode == "jwt"
+    names = set(module.mcp._tool_manager._tools)
+    assert not (names & CERT_ONLY_TOOLS), "task tools must be hidden in JWT mode"
+    assert ALWAYS_AVAILABLE_TOOLS <= names
+    assert len(names) == len(ALWAYS_AVAILABLE_TOOLS)
+
+
+def test_certificate_mode_exposes_every_tool(reload_server):
+    module = reload_server(
+        QLIK_SERVER_URL="https://qlik.example.com",
+        QLIK_USER_DIRECTORY="COMPANY",
+        QLIK_USER_ID="svc_mcp",
+    )
+    assert module.config.auth_mode == "certificate"
+    names = set(module.mcp._tool_manager._tools)
+    assert CERT_ONLY_TOOLS <= names
+    assert ALWAYS_AVAILABLE_TOOLS <= names
+
+
+def test_unconfigured_server_still_exposes_every_tool(reload_server):
+    """`--help` and a misconfigured host must not silently lose tools."""
+    module = reload_server()
+    names = set(module.mcp._tool_manager._tools)
+    assert CERT_ONLY_TOOLS <= names
+    assert ALWAYS_AVAILABLE_TOOLS <= names


### PR DESCRIPTION
## Summary

Sorting a hypercube by a measure never worked. `qInterColumnSortOrder` was hard-coded to `list(range(n_cols))`, so the first dimension always won and the per-measure `qSortBy` was dead configuration — every "top 10 by revenue" request silently returned the 10 alphabetically first rows. Plausible data, wrong order.

`engine_create_hypercube` now maps onto SQL one-to-one:

```jsonc
{
  "dimensions": [{"field": "clientid"}],
  "measures":   [{"expression": "Sum(ggr)", "label": "GGR"}],
  "sort_by": "GGR", "sort_order": "desc", "limit": 10
}
```

## Verification against a live 91M-row app

| Scenario | Time | Result |
|---|---|---|
| top-10 desc (9647 groups) | 0.23s | 10.0 → 5.3 → 4.6 → 4.2 bn |
| bottom-10 asc | 0.22s | −76.9 → −34.2 → −33.4 m |
| sort by dimension | 0.21s | ok |
| `sort_by="Revenue"` (unknown) | 0.00s | `invalid_sort` + `available_columns` |

Correctness was checked independently: all 1217 groups of another breakdown were pulled and sorted in Python — the Engine top-10 matched exactly.

Ranking via `sort_by` also avoids `qSortByExpression`, which the old docstring recommended and which makes the Engine evaluate the same aggregate a second time purely to order rows: **286s vs 0.2s** on the same data.

## Other changes

- `limit` as the primary name for `max_rows` (alias kept), plus `suppress_zero` and `include_raw_layout`
- Compact response: `columns` + `rows` with real numbers, `grand_total`, per-step `timings`
- Every failure — timeouts included — echoes `tool` + `request` with the exact arguments sent, implemented once in `_timed` so it covers all tools
- Reload-task tools registered in certificate mode only (they need QRS admin rights a JWT analyst lacks): 24 tools with a certificate, 12 with a JWT
- Qlik session limit (max 5 per user, lockout risk) documented in the Engine tool docstrings and docs
- Usage examples in every tool docstring; corrected docstrings that promised response keys the tools never returned
- Fixed: caller dicts were mutated, session objects were never destroyed, the timeout hint named a non-existent env var

## Breaking-ish

The hypercube response is compact by default. Callers relying on `hypercube_data.qDataPages[0].qMatrix` need `include_raw_layout: true`.

## Tests

149 passed (was 97), offline — 52 new tests cover sort resolution, the generated `qHyperCubeDef`, guard rails, the request echo and per-mode tool visibility.