### PR TITLE
Release v1.6.1 — keep the NULL dimension row out of rankings

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.6.0
+current_version = 1.6.1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [1.6.1] - 2026-07-28
 
 ### Fixed
+- **Pinned `mcp<2.0.0` — the server would not start otherwise.** MCP SDK
+  2.0.0 was released on 2026-07-28 and removes `mcp.server.fastmcp`, the
+  FastMCP host this server is built on, in favour of a new
+  `mcp.server.mcpserver` API. Because the dependency was declared as
+  `mcp>=1.1.0`, every fresh install — including 1.6.0 and every earlier
+  release — resolved to 2.0.0 and died at import with
+  `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`. The pin
+  restores installability; porting to the 2.x API is a separate piece of
+  work.
 - **The NULL dimension row no longer hijacks a ranking.** Facts that
   carry no value for the grouping field all collapse into a single row
   that Qlik renders as `"-"`, so that row often holds a very large total

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.6.1] - 2026-07-28
+
+### Fixed
+- **The NULL dimension row no longer hijacks a ranking.** Facts that
+  carry no value for the grouping field all collapse into a single row
+  that Qlik renders as `"-"`, so that row often holds a very large total
+  and takes first place in a top-N, pushing out every real value.
+  `engine_create_hypercube` now sets `qNullSuppression` on every
+  dimension. Observed on a live app: the `"-"` row held the entire
+  measure total and occupied rank 1 of the result.
+
+### Added
+- **`exclude_null_dimensions`** on `engine_create_hypercube`, default
+  `True`. Pass `False` to keep the `"-"` row — useful precisely when you
+  want to measure how much data is unattributed, since a large `"-"`
+  total means the grouping field is not linked to those facts in the
+  data model.
+
 ## [1.6.0] - 2026-07-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ secrets). See [`docs/AUTH_JWT.md`](docs/AUTH_JWT.md) for the JWT setup.
   measure silently did nothing — `qInterColumnSortOrder` was hard-coded
   to the dimensions, so the server returned the alphabetically first
   rows instead of the largest ones.
+- **NULL groups stay out of rankings.** Facts with no value for the
+  grouping field collapse into Qlik's `"-"` row, which often holds a
+  large total and would otherwise take first place in a top-N. It is
+  dropped by default; pass `exclude_null_dimensions=false` to measure
+  how much data is unattributed.
 - **Compact, LLM-friendly results.** The hypercube response is
   `columns` + `rows` with real numbers, plus `grand_total` and
   per-step `timings`. Pass `include_raw_layout=true` for the full Qlik

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,6 +134,13 @@ Unknown `sort_by` / `sort_order` values fail fast with an
 — silently ignoring a sort would return plausible rows in the wrong
 order, which is worse than an error.
 
+Since v1.6.1 every dimension also carries `qNullSuppression` (opt out
+with `exclude_null_dimensions=False`). Facts that carry no value for the
+grouping field collapse into one row that Qlik renders as `"-"`, and
+that row frequently holds a large enough total to win the ranking. On a
+live app it held the entire measure total and took rank 1, hiding every
+real value behind it.
+
 #### Response shape
 
 The tool returns `columns` + `rows` (plain values, numbers preserved),

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -42,7 +42,7 @@ categories. The lists below are a quick map only.
 | `get_app_field` | Distinct values of one field with pagination and wildcard search. Falls back to a single-dimension hypercube if the underlying `ListObject` returns nothing. |
 | `engine_get_field_range` | Lightning-fast bounds for one field: count distinct, min, max. Implemented as a measures-only hypercube — runs in seconds on any table size. Prefer this over `get_app_field_statistics`. |
 | `get_app_field_statistics` | Field statistics via a measures-only hypercube. Defaults to **light** mode (count distinct, count, non-null count, min, max, null %, completeness). Pass `full=true` to also compute avg / sum / median / mode / stdev — slow on big fact tables and meaningless for date/text fields. |
-| `engine_create_hypercube` | Build an arbitrary `GROUP BY` hypercube — the main data-analysis tool. Supports ranking directly: `sort_by` (measure label / measure expression / dimension field) + `sort_order` (`desc` / `asc`) + `limit`. Hard limits: `limit <= 5000`, `columns * limit <= 9900`. Read the full docstring — it covers set-analysis patterns, the no-expression-in-dimension rule and the session limit. |
+| `engine_create_hypercube` | Build an arbitrary `GROUP BY` hypercube — the main data-analysis tool. Supports ranking directly: `sort_by` (measure label / measure expression / dimension field) + `sort_order` (`desc` / `asc`) + `limit`. Rows with a NULL dimension value (Qlik's `"-"`) are dropped by default — pass `exclude_null_dimensions=false` to keep them. Hard limits: `limit <= 5000`, `columns * limit <= 9900`. Read the full docstring — it covers set-analysis patterns, the no-expression-in-dimension rule and the session limit. |
 
 ## Task management (Repository API)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -98,6 +98,14 @@ Engine evaluate the same aggregate a second time just to order rows. On
 a 91M-row app, ranking by the measure column returned in 0.2s where the
 `qSortByExpression` form took 286s.
 
+Rows whose dimension value is NULL — displayed by Qlik as `"-"` — are
+dropped by default (`exclude_null_dimensions`). Facts that carry no
+value for the grouping field all pile into that one row, so it tends to
+hold a large total and win the ranking. Pass
+`"exclude_null_dimensions": false` when you specifically want to see how
+much data is unattributed: a large `"-"` total means the grouping field
+is not linked to those facts in the data model.
+
 ## One session at a time
 
 Qlik Sense allows at most **5 concurrent sessions per user identity**,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,10 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Information Analysis"
 ]
 dependencies = [
-    "mcp>=1.1.0",
+    # mcp 2.0.0 (2026-07-28) removed mcp.server.fastmcp entirely — the whole
+    # FastMCP host this server is built on. Pin below 2.0 until the server is
+    # ported to the new mcp.server.mcpserver API.
+    "mcp>=1.1.0,<2.0.0",
     "httpx>=0.25.0",
     "pydantic>=2.0.0",
     "python-dotenv>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qlik-sense-mcp-server"
-version = "1.6.0"
+version = "1.6.1"
 description = "MCP Server for Qlik Sense Enterprise APIs"
 readme = "README.md"
 license = {text = "MIT"}

--- a/qlik_sense_mcp_server/__init__.py
+++ b/qlik_sense_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Qlik Sense MCP Server for Enterprise APIs."""
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"

--- a/qlik_sense_mcp_server/engine_api.py
+++ b/qlik_sense_mcp_server/engine_api.py
@@ -1201,6 +1201,7 @@ class QlikEngineAPI:
         sort_order: str = "desc",
         suppress_zero: bool = False,
         include_raw_layout: bool = False,
+        exclude_null_dimensions: bool = True,
     ) -> Dict[str, Any]:
         """
         Create a hypercube (grouped aggregation) and return its first page.
@@ -1212,6 +1213,13 @@ class QlikEngineAPI:
         computed measure column costs nothing extra, unlike
         `qSortByExpression`, which makes the Engine evaluate the aggregate
         a second time purely for ordering.
+
+        `exclude_null_dimensions` (default True) sets `qNullSuppression`
+        on every dimension, dropping the row whose dimension value is
+        NULL (Qlik renders it as "-"). Unattributed facts often
+        accumulate into that single row, which then wins the ranking and
+        pushes out the real values — a top-10 that starts with "unknown"
+        is rarely what the caller wanted.
         """
         import time
         import traceback as _tb
@@ -1432,7 +1440,7 @@ class QlikEngineAPI:
                                 }
                             ],
                         },
-                        "qNullSuppression": False,
+                        "qNullSuppression": bool(exclude_null_dimensions),
                         "qIncludeElemValue": True,
                     }
                     for dim in converted_dimensions

--- a/qlik_sense_mcp_server/server.py
+++ b/qlik_sense_mcp_server/server.py
@@ -834,6 +834,7 @@ def engine_create_hypercube(
     sort_by: Optional[str] = None,
     sort_order: str = "desc",
     suppress_zero: bool = False,
+    exclude_null_dimensions: bool = True,
     include_raw_layout: bool = False,
     max_rows: Optional[int] = None,
 ) -> str:
@@ -1019,6 +1020,14 @@ def engine_create_hypercube(
         suppress_zero: Drop rows whose measure is 0. Default False.
             Useful for `sort_order="asc"`, where zero-valued groups
             would otherwise fill the entire result.
+        exclude_null_dimensions: Drop the row whose dimension value is
+            NULL — the one Qlik displays as `"-"`. Default True.
+            Facts that carry no value for the grouping field all pile
+            into that single row, so it frequently holds a large total
+            and wins the ranking, pushing the real values out of a
+            top-N. Pass False when you specifically want to see how much
+            data is unattributed — a large `"-"` row means the grouping
+            field is not linked to those facts in the data model.
         include_raw_layout: Also return the untouched Qlik `qHyperCube`
             (per-cell `qElemNumber`/`qState`, `qDimensionInfo`,
             `qMeasureInfo`). Default False, because it costs several
@@ -1074,6 +1083,7 @@ def engine_create_hypercube(
             sort_order=sort_order,
             suppress_zero=suppress_zero,
             include_raw_layout=include_raw_layout,
+            exclude_null_dimensions=exclude_null_dimensions,
         )
         # Opening the app dominates the first call against a cold app, so
         # report it next to the query time instead of hiding it in the

--- a/tests/test_hypercube.py
+++ b/tests/test_hypercube.py
@@ -144,6 +144,23 @@ class TestHypercubeDefinition:
         eng.create_hypercube(1, DIMS, MEASURES, 10, suppress_zero=True)
         assert eng.cube_def["qSuppressZero"] is True
 
+    def test_null_dimension_rows_are_dropped_by_default(self):
+        """Unattributed facts pile into the "-" row and hijack a top-N."""
+        eng = _FakeEngine()
+        eng.create_hypercube(1, DIMS, MEASURES, 10, sort_by="GGR")
+        assert eng.cube_def["qDimensions"][0]["qNullSuppression"] is True
+
+    def test_null_dimension_rows_can_be_kept(self):
+        eng = _FakeEngine()
+        eng.create_hypercube(1, DIMS, MEASURES, 10, exclude_null_dimensions=False)
+        assert eng.cube_def["qDimensions"][0]["qNullSuppression"] is False
+
+    def test_null_suppression_applies_to_every_dimension(self):
+        eng = _FakeEngine()
+        dims = [{"field": "clientid"}, {"field": "Region"}]
+        eng.create_hypercube(1, dims, MEASURES, 10)
+        assert all(d["qNullSuppression"] is True for d in eng.cube_def["qDimensions"])
+
     def test_page_height_follows_limit(self):
         eng = _FakeEngine()
         eng.create_hypercube(1, DIMS, MEASURES, 25)


### PR DESCRIPTION
## Problem

Facts that carry no value for the grouping field all collapse into a single row that Qlik renders as `"-"`. That row therefore holds a large total and takes **first place** in a top-N, pushing out every real value.

Observed on a live app while verifying v1.6.0: grouping by a club field, the `"-"` row held the entire measure total and occupied rank 1, while all 1216 real clubs sat at 0 behind it.

## Fix

`engine_create_hypercube` now sets `qNullSuppression` on every dimension.

New parameter `exclude_null_dimensions`, default `True`. Pass `false` to keep the `"-"` row — which is exactly what you want when the question is *"how much of this data is unattributed?"*, since a large `"-"` total means the grouping field is not linked to those facts in the data model.

## Verified on live data

```
Клуб top-5 desc — nulls EXCLUDED (new default)   groups=1204
   ['А. Султана 0521(закрыт)', 0] ...

Клуб top-5 desc — nulls KEPT (opt-out)           groups=1205
   ['-', 57603368189.32]        <- used to win every ranking
   ['А. Султана 0521(закрыт)', 0] ...
```

A ranking over a fact-table dimension is unaffected (top-5 unchanged, 0.22s).

## Tests

152 passed (was 149) — three new cases cover the default, the opt-out, and multi-dimension cubes.