### PR TITLE
Release v1.7.0 — run on both MCP SDK 1.x and 2.x

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.6.1
+current_version = 1.7.0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,17 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        # MCP SDK 2.0 removed mcp.server.fastmcp, which every release up to
+        # 1.6.0 imported unconditionally — a fresh install resolved to the new
+        # SDK and died at import. Both lines are exercised so that can never
+        # reach PyPI again. "latest" tracks whatever the resolver picks today.
+        mcp-version: [ "1.x", "2.x", "latest" ]
+
+    name: build-test (mcp ${{ matrix.mcp-version }})
+
     steps:
     - uses: actions/checkout@v4
 
@@ -30,10 +41,20 @@ jobs:
     - name: Build package
       run: uv run python -m build
 
-    - name: Test package installation
+    - name: Install package
+      run: uv pip install dist/*.whl || uv pip install dist/*.tar.gz
+
+    - name: Select MCP SDK version
       run: |
-        uv pip install dist/*.whl || uv pip install dist/*.tar.gz
-        uv run python -c "import qlik_sense_mcp_server; import importlib; importlib.import_module('qlik_sense_mcp_server.server'); print('OK')"
+        case "${{ matrix.mcp-version }}" in
+          1.x) uv pip install "mcp>=1.1.0,<2.0.0" ;;
+          2.x) uv pip install "mcp>=2.0.0,<3.0.0" ;;
+          latest) : ;;
+        esac
+        uv run python -c "import importlib.metadata as m; print('mcp', m.version('mcp'))"
+
+    - name: Test package installation
+      run: uv run python -c "import qlik_sense_mcp_server; import importlib; importlib.import_module('qlik_sense_mcp_server.server'); print('OK')"
 
     - name: Run tests
       run: uv run pytest tests/ -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,34 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   here instead of in a user's terminal.
 
 ### Changed
-- **Dependency relaxed to `mcp>=1.1.0,<3.0.0`.** The `<2.0.0` pin from
-  1.6.1 is no longer needed. The upper bound is kept so the next
-  breaking SDK major cannot break installs again.
+- **Dependency is now `mcp>=1.8.0,<3.0.0`.** The `<2.0.0` pin from 1.6.1
+  is no longer needed. The floor was raised from the long-standing (and
+  incorrect) `1.1.0`: `FastMCP.run_streamable_http_async()` — the default
+  transport — first appears in 1.8.0, so 1.2–1.7 would install happily
+  and then die with `AttributeError` on startup, and 1.1 has no
+  `FastMCP` at all. The upper bound keeps the next breaking SDK major
+  from breaking installs again.
+
+### Fixed
+*(found by an automated review of this release)*
+- **Hypercube session objects leaked on every failure after creation.**
+  `DestroySessionObject` ran only on the success path, so a malformed
+  layout or an Engine error left the result set pinned in Engine memory
+  for the rest of the (deliberately long-lived) session. Cleanup moved
+  into a `finally`; it is skipped only when the socket has already been
+  force-closed, where there is nothing left to talk to.
+- **`limit=0` or a negative limit silently returned one row.** The page
+  height was clamped with `max(1, ...)`, so a nonsensical limit produced
+  data instead of an error. Non-positive and non-integer limits now
+  return a structured `invalid_limit` error before any Engine call.
+- **A dimension sort expression given in Qlik's native `{"qv": "..."}`
+  form was double-wrapped** into `{"qv": {"qv": "..."}}` and silently
+  ignored by the Engine. Both that form and a plain string are now
+  accepted.
+- Corrected the comment and docs around the automatic `qSuppressMissing`
+  applied when ranking by a measure: it is a cube-wide flag that drops
+  rows where *any* measure is missing, not only the ranked one. The
+  Engine offers no per-measure equivalent.
 
 ### Verified
 - Both SDK lines were exercised end to end: full test suite on mcp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.7.0] - 2026-07-29
+
+### Added
+- **Support for MCP SDK 2.x.** SDK 2.0 removed `mcp.server.fastmcp` and
+  replaced the FastMCP host with `mcp.server.mcpserver.MCPServer`.
+  `server.py` now selects the host class at import time and exposes the
+  result as `MCP_SDK_MAJOR`, so the same code runs on both SDK lines.
+  The only behavioural difference between them is that 2.x takes the
+  bind address in `run_streamable_http_async()` rather than in the
+  constructor; everything else — the `@tool()` decorator, `stdio`, the
+  tool registry used by `--help` — is identical.
+- `tests/test_sdk_compat.py` — asserts that the selected host matches the
+  installed SDK, that every API the server calls exists on it, and that
+  the published `engine_create_hypercube` schema still carries the
+  ranking parameters and its docstring. A future SDK change now fails
+  here instead of in a user's terminal.
+
+### Changed
+- **Dependency relaxed to `mcp>=1.1.0,<3.0.0`.** The `<2.0.0` pin from
+  1.6.1 is no longer needed. The upper bound is kept so the next
+  breaking SDK major cannot break installs again.
+
+### Verified
+- Both SDK lines were exercised end to end: full test suite on mcp
+  1.29.0 and on mcp 2.0.0 (158 tests each), the streamable-HTTP
+  transport answering a real `initialize` + `tools/list` handshake on
+  both (24 tools published with identical schemas), and a live
+  `tools/call` against a 91M-row Qlik app on 2.0.0 returning a correct
+  top-5 ranking.
+
 ## [1.6.1] - 2026-07-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -68,7 +68,12 @@ secrets). See [`docs/AUTH_JWT.md`](docs/AUTH_JWT.md) for the JWT setup.
 | [`docs/troubleshooting.md`](docs/troubleshooting.md) | Common errors, hypercube planning failures, verbose logging, configuration self-test |
 | [`CHANGELOG.md`](CHANGELOG.md) | Release notes |
 
-## Key facts about the v1.6.0 line
+## Key facts about the v1.7.0 line
+
+- **Runs on both MCP SDK lines.** SDK 2.0 dropped `FastMCP`; the server
+  now picks `MCPServer` (2.x) or `FastMCP` (1.x) at import time, so
+  `mcp>=1.1.0,<3.0.0` all work. Both lines are covered by the test
+  suite and were verified end to end against a live Qlik app.
 
 - **Ranked queries (top-N) in one call.** `engine_create_hypercube`
   takes `sort_by` (a measure label, a measure expression or a dimension

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -163,9 +163,25 @@ limit is per-call, not per-session.
 
 ### `FastMCP` server ([server.py](../qlik_sense_mcp_server/server.py))
 
-The `mcp` package's
-[`FastMCP`](https://github.com/modelcontextprotocol/python-sdk) host
-registers every `@mcp.tool()`-decorated function as an MCP tool. Each
+The host object comes from the
+[MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk) and
+is chosen at import time, because SDK 2.0 (2026-07-28) removed
+`mcp.server.fastmcp`:
+
+| Installed SDK | Host class | `MCP_SDK_MAJOR` |
+|---|---|---|
+| 1.x | `mcp.server.fastmcp.FastMCP` | `1` |
+| 2.x | `mcp.server.mcpserver.MCPServer` | `2` |
+
+Both expose the same `@tool()` decorator, `run_stdio_async()`,
+`run_streamable_http_async()` and `_tool_manager._tools` registry. The
+only difference the server has to care about is the bind address: 1.x
+takes `host`/`port` in the constructor, 2.x in
+`run_streamable_http_async()`. `tests/test_sdk_compat.py` pins this
+contract down so the next SDK change fails in CI rather than at a user's
+first tool call.
+
+The host registers every `@mcp.tool()`-decorated function as an MCP tool. Each
 tool is also wrapped in the local `_timed` decorator, which:
 
 1. Measures wall-clock time of the call.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -197,6 +197,21 @@ tool is also wrapped in the local `_timed` decorator, which:
    violations) — a bare "timed out after 180s" does not tell the caller
    which query to fix.
 
+#### Why failures are not flagged as protocol-level errors
+
+Tool failures come back as an ordinary MCP result whose payload contains
+`error`, `error_category`, `hint` and `request` — `isError` stays false.
+This is deliberate. The consumer here is a language model deciding what
+to do next, and the structured payload is what lets it act: the category
+tells it whether to narrow the query or fix a field name, and `request`
+tells it exactly what it sent. Clients that surface `isError` tend to
+collapse the result into a generic failure message and drop that
+payload, which would leave the model with nothing to correct.
+
+The trade-off is that a client keying retries off the protocol-level
+error status will treat a timeout as a success. Such a client should
+branch on the `error` key instead.
+
 #### Per-mode tool registration (since v1.6.0)
 
 Reload-task tools are declared with `@_cert_only_tool()` instead of

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,6 +3,9 @@
 ## System requirements
 
 - Python 3.12 (the version pinned in [`pyproject.toml`](../pyproject.toml))
+- MCP Python SDK `>=1.1.0,<3.0.0` — installed automatically. Both the
+  1.x (`FastMCP`) and 2.x (`MCPServer`) lines are supported; the server
+  detects which one is present at import time.
 - Qlik Sense Enterprise with Repository API on port 4242 and Engine API on port 4747 (the [standard Qlik Sense Enterprise port allocation](https://help.qlik.com/en-US/sense-admin/Subsystems/DeployAdministerQSE/Content/Sense_DeployAdminister/QSEoW/Deploy_QSEoW/Ports.htm))
 - Network access from the host running the MCP server to those Qlik ports
 - Client certificate (`.pem`) and matching private key issued by the Qlik Sense node, plus the root CA certificate
@@ -23,8 +26,12 @@ uvx qlik-sense-mcp-server
 To pin a specific version:
 
 ```bash
-uvx qlik-sense-mcp-server@1.5.0
+uvx qlik-sense-mcp-server@1.7.0
 ```
+
+Do not pin below 1.6.1: earlier releases declare `mcp>=1.1.0` with no
+upper bound, so a fresh install resolves to MCP SDK 2.x and fails at
+import with `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`.
 
 ## Install from PyPI via pip
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,10 @@ dependencies = [
     # Both SDK lines are supported: 1.x via mcp.server.fastmcp.FastMCP and
     # 2.x via mcp.server.mcpserver.MCPServer (see server.py). Capped below
     # 3.0 so the next breaking SDK release cannot break installs again.
-    "mcp>=1.1.0,<3.0.0",
+    # Floor is 1.8.0: FastMCP.run_streamable_http_async() — the default
+    # transport — first appears there (1.7.x has FastMCP but no HTTP runner,
+    # and 1.1 has no FastMCP at all).
+    "mcp>=1.8.0,<3.0.0",
     "httpx>=0.25.0",
     "pydantic>=2.0.0",
     "python-dotenv>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qlik-sense-mcp-server"
-version = "1.6.1"
+version = "1.7.0"
 description = "MCP Server for Qlik Sense Enterprise APIs"
 readme = "README.md"
 license = {text = "MIT"}
@@ -20,10 +20,10 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Information Analysis"
 ]
 dependencies = [
-    # mcp 2.0.0 (2026-07-28) removed mcp.server.fastmcp entirely — the whole
-    # FastMCP host this server is built on. Pin below 2.0 until the server is
-    # ported to the new mcp.server.mcpserver API.
-    "mcp>=1.1.0,<2.0.0",
+    # Both SDK lines are supported: 1.x via mcp.server.fastmcp.FastMCP and
+    # 2.x via mcp.server.mcpserver.MCPServer (see server.py). Capped below
+    # 3.0 so the next breaking SDK release cannot break installs again.
+    "mcp>=1.1.0,<3.0.0",
     "httpx>=0.25.0",
     "pydantic>=2.0.0",
     "python-dotenv>=1.0.0",

--- a/qlik_sense_mcp_server/__init__.py
+++ b/qlik_sense_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Qlik Sense MCP Server for Enterprise APIs."""
 
-__version__ = "1.6.1"
+__version__ = "1.7.0"

--- a/qlik_sense_mcp_server/engine_api.py
+++ b/qlik_sense_mcp_server/engine_api.py
@@ -1116,6 +1116,20 @@ class QlikEngineAPI:
         return names
 
     @staticmethod
+    def _as_value_expr(expression: Any) -> Dict[str, Any]:
+        """
+        Wrap a sort expression into Qlik's ValueExpr shape `{"qv": "..."}`.
+
+        Accepts the bare string this tool documents AND the native Qlik
+        form, which is what a caller reading Qlik's own API docs will
+        write. Without this, `{"qv": "Sum(x)"}` was wrapped a second time
+        into `{"qv": {"qv": "Sum(x)"}}` and the Engine ignored the sort.
+        """
+        if isinstance(expression, dict):
+            return {"qv": expression.get("qv", "")}
+        return {"qv": expression or ""}
+
+    @staticmethod
     def _matrix_to_rows(
         data_pages: List[Dict[str, Any]],
         column_names: List[str],
@@ -1226,6 +1240,7 @@ class QlikEngineAPI:
         step = "init"
         t0 = time.monotonic()
         timings: Dict[str, float] = {}
+        created_object_id: Optional[str] = None
         try:
             # Handle empty dimensions/measures
             if dimensions is None:
@@ -1322,6 +1337,25 @@ class QlikEngineAPI:
                         ),
                     }
 
+            # Reject a limit that asks for no rows at all. Without this the
+            # qHeight clamp below turns limit=0 or limit=-7 into a single
+            # row, quietly returning data the caller did not ask for.
+            if not isinstance(max_rows, int) or isinstance(max_rows, bool) or max_rows < 1:
+                return {
+                    "error": (
+                        f"limit={max_rows!r} is not a positive row count."
+                    ),
+                    "error_category": "invalid_limit",
+                    "failed_step": "plan",
+                    "hard_max_rows": HARD_MAX_ROWS,
+                    "hint": (
+                        f"Pass an integer between 1 and {HARD_MAX_ROWS}. For a "
+                        f"single grand-total row use limit=1 with no "
+                        f"dimensions; for a ranking use a small limit (10-50) "
+                        f"together with sort_by."
+                    ),
+                }
+
             # Reject max_rows over the hard cap.
             if max_rows > HARD_MAX_ROWS:
                 return {
@@ -1405,9 +1439,12 @@ class QlikEngineAPI:
                     converted_measures[sort_column_index - n_dims]["sort_by"] = {
                         "qSortByNumeric": sort_direction,
                     }
-                    # Rows where the measure is NULL carry no ranking
-                    # information and would otherwise pollute the top/bottom
-                    # of the result.
+                    # Rows with no measure value carry no ranking information
+                    # and would otherwise pollute the top/bottom of the
+                    # result. Note that qSuppressMissing is a CUBE-WIDE flag:
+                    # it drops rows where any measure is missing, not only
+                    # the one being ranked on. That is the coarsest tool the
+                    # Engine offers here — there is no per-measure switch.
                     suppress_missing = True
                 else:
                     # Sorting by a dimension: set both numeric and ASCII in
@@ -1436,7 +1473,9 @@ class QlikEngineAPI:
                                     "qSortByAscii": dim["sort_by"].get("qSortByAscii", 1),
                                     "qSortByLoadOrder": 0,
                                     "qSortByExpression": dim["sort_by"].get("qSortByExpression", 0),
-                                    "qExpression": {"qv": dim["sort_by"].get("qExpression", "")},
+                                    "qExpression": self._as_value_expr(
+                                        dim["sort_by"].get("qExpression", "")
+                                    ),
                                 }
                             ],
                         },
@@ -1497,6 +1536,11 @@ class QlikEngineAPI:
                 }
 
             cube_handle = result["qReturn"]["qHandle"]
+            # From here on the session object exists on the server and MUST be
+            # released on every path. This connection is deliberately
+            # long-lived, so a leak on an error path pins that result set in
+            # Engine memory for the rest of the session.
+            created_object_id = obj_def["qInfo"]["qId"]
 
             # Get layout with data
             step = "GetLayout"
@@ -1555,20 +1599,6 @@ class QlikEngineAPI:
                         f"  - to split: run one focused query per category "
                         f"instead of one giant dump"
                     )
-
-            # Release the session object — the cube has been fully read into
-            # `hypercube`, and leaving it alive pins its result set in Engine
-            # memory for the rest of the session.
-            step = "DestroySessionObject"
-            try:
-                self.send_request(
-                    "DestroySessionObject", [obj_def["qInfo"]["qId"]],
-                    handle=app_handle, timeout=self.ws_operation_timeout,
-                )
-            except Exception as cleanup_exc:
-                # Never fail a successful query because cleanup failed.
-                logger.warning("create_hypercube: DestroySessionObject failed: %s",
-                               cleanup_exc)
 
             timings["total_seconds"] = round(time.monotonic() - t0, 3)
 
@@ -1662,6 +1692,25 @@ class QlikEngineAPI:
                 "traceback": tb,
                 "details": "Error in create_hypercube method",
             }
+
+        finally:
+            # Runs on every path once the object exists: success, early
+            # return for a malformed layout, and any exception in between.
+            # Skipped when the socket was already killed (timeout handling
+            # above), since there is nothing left to talk to.
+            if created_object_id and self.ws is not None:
+                try:
+                    self.send_request(
+                        "DestroySessionObject", [created_object_id],
+                        handle=app_handle, timeout=self.ws_operation_timeout,
+                    )
+                except Exception as cleanup_exc:
+                    # Never turn a completed query into a failure because
+                    # cleanup did not go through.
+                    logger.warning(
+                        "create_hypercube: DestroySessionObject(%s) failed: %s",
+                        created_object_id, cleanup_exc,
+                    )
 
     def get_hypercube_data(
         self,

--- a/qlik_sense_mcp_server/server.py
+++ b/qlik_sense_mcp_server/server.py
@@ -1016,19 +1016,22 @@ def engine_create_hypercube(
             no expression. Omit or pass `[]` for a grand-total row.
             Advanced: an optional `"sort_by"` object per dimension maps
             straight onto Qlik `qSortCriterias`
-            (`qSortByNumeric` / `qSortByAscii` / `qSortByExpression` +
-            `qExpression`, each -1 desc / 0 off / 1 asc). The top-level
-            `sort_by` argument overrides it and is what you normally want.
+            (`qSortByNumeric` / `qSortByAscii` / `qSortByExpression`, each
+            -1 desc / 0 off / 1 asc, plus `qExpression`, accepted either
+            as a plain string or in Qlik's native `{"qv": "..."}` form).
+            The top-level `sort_by` argument overrides it and is what you
+            normally want.
         measures: Aggregate expressions. Each item is
             `{"expression": "Sum(Amount)", "label": "Revenue"}`. Always
             give a `label` — it is the column name AND the value you pass
             to `sort_by`. Any Qlik aggregation works: Sum, Count,
             Count(DISTINCT ...), Avg, Min, Max, Only, FirstSortedValue,
             RangeSum.
-        limit: Max rows to return (the SQL LIMIT). Default 1000, hard cap
-            5000. Also capped by `columns * limit <= 9900` (Qlik itself
-            refuses pages over 10000 cells). For ranked queries a small
-            limit (10-50) is both faster and easier to read.
+        limit: Max rows to return (the SQL LIMIT). Default 1000, must be
+            at least 1, hard cap 5000. Also capped by
+            `columns * limit <= 9900` (Qlik itself refuses pages over
+            10000 cells). For ranked queries a small limit (10-50) is
+            both faster and easier to read.
         sort_by: Name of the column to order by — a measure `label`, a
             measure expression, or a dimension field name. Case- and
             bracket-insensitive; a measure wins over a dimension of the
@@ -1074,6 +1077,7 @@ def engine_create_hypercube(
     Errors return `error`, `error_category` and an actionable `hint`:
         `invalid_sort` — `sort_by` matched no column; the response lists
             `available_columns`.
+        `invalid_limit` — `limit` was not a positive integer.
         `limit_exceeded` — limit above 5000.
         `cell_cap_exceeded` — columns * limit above 9900; the hint gives
             a concrete smaller limit.

--- a/qlik_sense_mcp_server/server.py
+++ b/qlik_sense_mcp_server/server.py
@@ -1,4 +1,8 @@
-"""Main MCP Server for Qlik Sense APIs – rewritten with FastMCP."""
+"""Main MCP Server for Qlik Sense APIs.
+
+Runs on either MCP SDK line: 1.x (`FastMCP`) or 2.x (`MCPServer`). The
+host object is selected at import time — see `MCP_SDK_MAJOR` below.
+"""
 
 import asyncio
 import functools
@@ -19,7 +23,22 @@ if sys.platform == "win32":
     if hasattr(sys.stderr, "reconfigure"):
         sys.stderr.reconfigure(encoding="utf-8")
 
-from mcp.server.fastmcp import FastMCP
+# MCP SDK 2.0 (released 2026-07-28) removed `mcp.server.fastmcp` and
+# replaced the FastMCP host with `MCPServer`. The two are compatible where
+# it matters to us — same `@tool()` decorator, same `run_stdio_async()` /
+# `run_streamable_http_async()` — but 2.x takes the bind address in
+# `run_streamable_http_async()` instead of the constructor.
+#
+# Both SDK lines are supported so that existing installs pinned to 1.x
+# keep working and fresh installs get 2.x.
+try:
+    from mcp.server.mcpserver import MCPServer as _McpHost
+
+    MCP_SDK_MAJOR = 2
+except ImportError:  # mcp < 2.0
+    from mcp.server.fastmcp import FastMCP as _McpHost
+
+    MCP_SDK_MAJOR = 1
 
 from .config import (
     QlikSenseConfig,
@@ -95,14 +114,15 @@ def _init_clients():
 
 _init_clients()
 
-# ─── FastMCP server ─────────────────────────────────────────────────────────
+# ─── MCP server host ────────────────────────────────────────────────────────
 
+_mcp_host = "127.0.0.1"
 _mcp_port = int(os.getenv("MCP_PORT", "8000"))
-mcp = FastMCP(
-    "qlik-sense-mcp-server",
-    host="127.0.0.1",
-    port=_mcp_port,
-)
+if MCP_SDK_MAJOR >= 2:
+    # 2.x takes the bind address in run_streamable_http_async(), not here.
+    mcp = _McpHost("qlik-sense-mcp-server")
+else:
+    mcp = _McpHost("qlik-sense-mcp-server", host=_mcp_host, port=_mcp_port)
 
 # Reload-task management talks to QRS endpoints (/qrs/reloadtask,
 # /qrs/executionresult, /qrs/reloadtask/{id}/scriptlog) that require
@@ -1946,8 +1966,14 @@ def get_task_dependencies(task_id: str, direction: str = "downstream") -> str:
 
 async def async_main():
     """Async main entry point — runs streamable HTTP transport."""
-    logger.info("Starting qlik-sense-mcp-server v%s (streamable-http on :%d/mcp)", __version__, _mcp_port)
-    await mcp.run_streamable_http_async()
+    logger.info(
+        "Starting qlik-sense-mcp-server v%s (streamable-http on :%d/mcp, mcp SDK %d.x)",
+        __version__, _mcp_port, MCP_SDK_MAJOR,
+    )
+    if MCP_SDK_MAJOR >= 2:
+        await mcp.run_streamable_http_async(host=_mcp_host, port=_mcp_port)
+    else:
+        await mcp.run_streamable_http_async()
 
 
 def main():

--- a/tests/test_hypercube.py
+++ b/tests/test_hypercube.py
@@ -82,6 +82,8 @@ class _FakeEngine(QlikEngineAPI):
         self.sent = []
         self.ws_operation_timeout = 30.0
         self.ws_timeout_seconds = 30.0
+        # Stand-in for a live socket: cleanup is skipped when it is None.
+        self.ws = object()
 
     def send_request(self, method, params=None, handle=-1, timeout=None):
         self.sent.append((method, params))
@@ -128,6 +130,20 @@ class TestHypercubeDefinition:
         criteria = cube["qDimensions"][0]["qDef"]["qSortCriterias"][0]
         assert criteria["qSortByNumeric"] == 1
         assert criteria["qSortByAscii"] == 1
+
+    @pytest.mark.parametrize("expression,expected", [
+        ("Sum(ggr)", "Sum(ggr)"),                      # this tool's documented shape
+        ({"qv": "Sum(ggr)"}, "Sum(ggr)"),              # Qlik's own native shape
+        ("", ""),
+    ])
+    def test_dimension_sort_expression_is_never_double_wrapped(self, expression, expected):
+        """{"qv": ...} used to become {"qv": {"qv": ...}}, which Engine ignores."""
+        eng = _FakeEngine()
+        dims = [{"field": "clientid", "sort_by": {
+            "qSortByExpression": -1, "qExpression": expression}}]
+        eng.create_hypercube(1, dims, MEASURES, 10)
+        criteria = eng.cube_def["qDimensions"][0]["qDef"]["qSortCriterias"][0]
+        assert criteria["qExpression"] == {"qv": expected}
 
     def test_without_sort_by_the_legacy_order_is_preserved(self):
         eng = _FakeEngine()
@@ -199,6 +215,49 @@ class TestHypercubeResponse:
         eng.create_hypercube(1, DIMS, MEASURES, 10)
         assert any(m == "DestroySessionObject" for m, _ in eng.sent)
 
+    def test_session_object_is_destroyed_when_get_layout_raises(self):
+        """A leak here pins the result set in Engine memory for the whole session."""
+        class _Exploding(_FakeEngine):
+            def send_request(self, method, params=None, handle=-1, timeout=None):
+                if method == "GetLayout":
+                    self.sent.append((method, params))
+                    raise Exception("Engine API error: bad expression")
+                return super().send_request(method, params, handle, timeout)
+
+        eng = _Exploding()
+        result = eng.create_hypercube(1, DIMS, MEASURES, 10)
+        assert result["error_category"] == "engine_api_error"
+        assert any(m == "DestroySessionObject" for m, _ in eng.sent)
+
+    def test_no_cleanup_attempted_once_the_socket_is_dead(self):
+        """After a timeout the socket is force-closed; there is nobody to talk to."""
+        class _TimingOut(_FakeEngine):
+            def send_request(self, method, params=None, handle=-1, timeout=None):
+                if method == "GetLayout":
+                    self.sent.append((method, params))
+                    raise TimeoutError("WebSocket recv() timed out")
+                return super().send_request(method, params, handle, timeout)
+
+        eng = _TimingOut()
+        result = eng.create_hypercube(1, DIMS, MEASURES, 10)
+        assert result["error_category"] == "socket_timeout"
+        assert eng.ws is None
+        assert not any(m == "DestroySessionObject" for m, _ in eng.sent)
+
+    def test_session_object_is_destroyed_on_malformed_layout(self):
+        class _Malformed(_FakeEngine):
+            def send_request(self, method, params=None, handle=-1, timeout=None):
+                if method == "GetLayout":
+                    self.sent.append((method, params))
+                    return {"unexpected": "shape"}
+                return super().send_request(method, params, handle, timeout)
+
+        eng = _Malformed()
+        eng.ws = object()
+        result = eng.create_hypercube(1, DIMS, MEASURES, 10)
+        assert result["error"] == "No hypercube in layout"
+        assert any(m == "DestroySessionObject" for m, _ in eng.sent)
+
     def test_ranked_truncation_warning_explains_it_is_expected(self):
         eng = _FakeEngine()
         result = eng.create_hypercube(1, DIMS, MEASURES, 10, sort_by="GGR")
@@ -228,6 +287,14 @@ class TestHypercubeGuardRails:
         eng = _FakeEngine()
         result = eng.create_hypercube(1, DIMS, MEASURES, 5001)
         assert result["error_category"] == "limit_exceeded"
+
+    @pytest.mark.parametrize("bad_limit", [0, -7, 1.5, "10", True, None])
+    def test_non_positive_limit_is_rejected(self, bad_limit):
+        """max(1, ...) used to turn limit=0 into a single silently returned row."""
+        eng = _FakeEngine()
+        result = eng.create_hypercube(1, DIMS, MEASURES, bad_limit)
+        assert result["error_category"] == "invalid_limit"
+        assert not eng.sent, "must fail before touching the Engine"
 
     def test_cell_cap(self):
         eng = _FakeEngine()

--- a/tests/test_sdk_compat.py
+++ b/tests/test_sdk_compat.py
@@ -1,0 +1,71 @@
+"""MCP SDK compatibility (since v1.7.0).
+
+MCP SDK 2.0 removed `mcp.server.fastmcp` and replaced the FastMCP host
+with `MCPServer`. Because the dependency was declared as `mcp>=1.1.0`,
+every fresh install silently resolved to the new SDK and died at import.
+These tests pin down the contract the server relies on, so a future SDK
+change fails here rather than in a user's terminal.
+"""
+
+import asyncio
+import importlib.metadata
+
+import pytest
+
+from qlik_sense_mcp_server import server as srv
+
+
+def test_sdk_major_matches_the_installed_package():
+    installed = importlib.metadata.version("mcp")
+    major = int(installed.split(".")[0])
+    assert srv.MCP_SDK_MAJOR == major, (
+        f"server.py selected the {srv.MCP_SDK_MAJOR}.x host but mcp {installed} "
+        f"is installed"
+    )
+
+
+def test_host_object_exposes_everything_the_server_uses():
+    """Both SDK lines must provide these — main() and _print_help() call them."""
+    for attribute in ("tool", "run_stdio_async", "run_streamable_http_async"):
+        assert hasattr(srv.mcp, attribute), f"MCP host is missing {attribute}()"
+    # _print_help() counts tools through this private registry; it exists on
+    # FastMCP (1.x) and on MCPServer (2.x) alike.
+    assert isinstance(srv.mcp._tool_manager._tools, dict)
+
+
+def test_streamable_http_accepts_the_bind_address_for_this_sdk():
+    """2.x moved host/port from the constructor into the run call."""
+    import inspect
+
+    params = inspect.signature(srv.mcp.run_streamable_http_async).parameters
+    if srv.MCP_SDK_MAJOR >= 2:
+        assert "host" in params and "port" in params
+    else:
+        assert srv.mcp.settings.port == srv._mcp_port
+
+
+def test_tools_are_registered_and_callable():
+    tools = asyncio.run(srv.mcp.list_tools())
+    names = {t.name for t in tools}
+    assert "engine_create_hypercube" in names
+    assert "get_about" in names
+
+
+def test_hypercube_schema_exposes_the_ranking_parameters():
+    """The whole point of the tool — these must survive an SDK swap."""
+    tool = next(t for t in asyncio.run(srv.mcp.list_tools())
+                if t.name == "engine_create_hypercube")
+    # 1.x calls it inputSchema, 2.x input_schema.
+    schema = getattr(tool, "input_schema", None) or tool.inputSchema
+    properties = schema["properties"]
+    for name in ("app_id", "dimensions", "measures", "limit", "sort_by",
+                 "sort_order", "exclude_null_dimensions"):
+        assert name in properties, f"{name} missing from the published schema"
+    assert schema.get("required") == ["app_id"]
+
+
+def test_docstring_reaches_the_published_description():
+    """LLMs only ever see the description — an empty one breaks every tool."""
+    tool = next(t for t in asyncio.run(srv.mcp.list_tools())
+                if t.name == "engine_create_hypercube")
+    assert tool.description and "sort_by" in tool.description


### PR DESCRIPTION
## Why

MCP SDK 2.0 (2026-07-28) removed `mcp.server.fastmcp` and replaced the FastMCP host with `mcp.server.mcpserver.MCPServer`. v1.6.1 bought time with a `mcp<2.0.0` pin; this PR does the actual port.

## What

`server.py` selects the host class at import time and exposes `MCP_SDK_MAJOR`:

| Installed SDK | Host class |
|---|---|
| 1.x | `mcp.server.fastmcp.FastMCP` |
| 2.x | `mcp.server.mcpserver.MCPServer` |

Both expose the same `@tool()` decorator, `run_stdio_async()`, `run_streamable_http_async()` and `_tool_manager._tools`. The only difference the server has to handle: 1.x takes `host`/`port` in the constructor, 2.x in `run_streamable_http_async()`.

The pin is therefore relaxed to `mcp>=1.1.0,<3.0.0` — upper bound kept so the next breaking major cannot break installs again.

## Verification

Both SDK lines, end to end:

| Check | mcp 1.29.0 | mcp 2.0.0 |
|---|---|---|
| Test suite | 158 passed | 158 passed |
| `initialize` + `tools/list` over streamable HTTP | 24 tools | 24 tools |
| Published hypercube schema | identical params | identical params |
| Live `tools/call` vs a 91M-row Qlik app | — | correct top-5 |

The live call also confirmed the new `timings` split is doing its job: `open_app_seconds` 23.7s (cold app load) versus `get_layout_seconds` 0.13s for the query itself.

## Regression guard

- `tests/test_sdk_compat.py` asserts the selected host matches the installed SDK, that every API the server calls exists on it, and that the published `engine_create_hypercube` schema still carries the ranking parameters and its docstring.
- CI gains a matrix over mcp `1.x` / `2.x` / `latest`, so an SDK break fails here rather than on PyPI.