### PR TITLE
Release v1.7.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.7.0
+current_version = 1.7.1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.7.1] - 2026-07-29
+
+### Fixed
+- **`ensure_app()` could cache a handle as "has data" when Engine actually
+  opened it without data.** The cached-connection reuse logic trusted the
+  requested `no_data` flag rather than checking what Engine actually did.
+  If a WebSocket session got shared/attached to an existing no-data
+  session for the same user+app, `GetAppLayout`/`GetAppProperties` still
+  succeeded, but `GetTablesAndKeys` silently returned `qtr: []` — an app
+  looked fully readable while its data model came back empty, with no
+  error surfaced. `ensure_app()` now reads Engine's own
+  `qIsOpenedWithoutData` from `GetAppLayout` right after `OpenDoc`,
+  retries once on a fresh connection if data was requested but not
+  granted, and raises `QlikEngineError` instead of returning a handle
+  that would later produce a silently empty data model.
+- Corrected misleading inline comments on `GetTablesAndKeys` positional
+  arguments (`qCellHeight` / `qSyntheticMode` / `qIncludeSysVars`) in
+  three call sites — the values were already correct, only the comments
+  describing them were wrong.
+
 ## [1.7.0] - 2026-07-29
 
 ### Added

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,7 +26,7 @@ uvx qlik-sense-mcp-server
 To pin a specific version:
 
 ```bash
-uvx qlik-sense-mcp-server@1.7.0
+uvx qlik-sense-mcp-server@1.7.1
 ```
 
 Do not pin below 1.6.1: earlier releases declare `mcp>=1.1.0` with no

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qlik-sense-mcp-server"
-version = "1.7.0"
+version = "1.7.1"
 description = "MCP Server for Qlik Sense Enterprise APIs"
 readme = "README.md"
 license = {text = "MIT"}

--- a/qlik_sense_mcp_server/__init__.py
+++ b/qlik_sense_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Qlik Sense MCP Server for Enterprise APIs."""
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"

--- a/qlik_sense_mcp_server/engine_api.py
+++ b/qlik_sense_mcp_server/engine_api.py
@@ -302,16 +302,61 @@ class QlikEngineAPI:
         # Pass app_id so connect() uses the per-app WebSocket endpoint first
         self.connect(app_id=app_id)
 
+        handle, has_data = self._open_doc_verified(app_id, no_data=no_data)
+
+        # If we need data but Qlik joined us to (or kept us on) a no-data
+        # session — e.g. session sharing attached to an existing no-data
+        # session for this user+app — retry once against a fresh connection
+        # before giving up. Trusting the requested `no_data` flag here is
+        # exactly the bug: GetAppLayout/GetAppProperties succeed regardless,
+        # so a stale no-data handle silently yields an empty data model
+        # later (GetTablesAndKeys returns qtr: []) instead of an error.
+        if needs_data and not has_data:
+            logger.warning(
+                "App %s opened without data despite no_data=False; "
+                "retrying with a fresh connection", app_id,
+            )
+            self.disconnect()
+            self.connect(app_id=app_id)
+            handle, has_data = self._open_doc_verified(app_id, no_data=no_data)
+            if not has_data:
+                self.disconnect()
+                raise QlikEngineError(
+                    f"App {app_id} remains opened without data (qIsOpenedWithoutData=True) "
+                    f"after retry — the data model will appear empty. This usually means "
+                    f"the Engine session was shared/attached to an existing no-data session "
+                    f"for this user+app."
+                )
+
+        self._cached_app_id = app_id
+        self._cached_app_handle = handle
+        self._cached_has_data = has_data
+        return handle
+
+    def _open_doc_verified(self, app_id: str, no_data: bool) -> "tuple[int, bool]":
+        """Open the doc and verify the real data state via GetAppLayout.
+
+        Returns (handle, has_data) where has_data reflects Engine's own
+        `qIsOpenedWithoutData` flag rather than the requested `no_data` —
+        the two can disagree when the session is shared/attached.
+        """
         app_result = self.open_doc(app_id, no_data=no_data)
         handle = app_result.get("qReturn", {}).get("qHandle", -1)
         if handle == -1:
             self.disconnect()
             raise Exception(f"Failed to open app {app_id}: {app_result}")
 
-        self._cached_app_id = app_id
-        self._cached_app_handle = handle
-        self._cached_has_data = not no_data
-        return handle
+        try:
+            layout = self.send_request("GetAppLayout", [], handle=handle)
+            opened_without_data = bool(
+                layout.get("qLayout", {}).get("qIsOpenedWithoutData", no_data)
+            )
+        except Exception:
+            # If we can't even verify, fall back to trusting the request —
+            # better than blocking on an unrelated GetAppLayout hiccup.
+            opened_without_data = no_data
+
+        return handle, not opened_without_data
 
     def _set_socket_timeout(self, timeout: float) -> None:
         """Set timeout on the underlying WebSocket socket."""
@@ -931,9 +976,9 @@ class QlikEngineAPI:
                 [
                     {"qcx": 1000, "qcy": 1000},  # Max dimensions
                     {"qcx": 0, "qcy": 0},  # Min dimensions
-                    30,  # Max tables
-                    True,  # Include system tables
-                    False,  # Include hidden fields
+                    30,  # qCellHeight
+                    True,  # qSyntheticMode
+                    False,  # qIncludeSysVars
                 ],
                 handle=app_handle,
             )
@@ -2874,9 +2919,9 @@ class QlikEngineAPI:
                 [
                     {"qcx": 1000, "qcy": 1000},  # Max dimensions
                     {"qcx": 0, "qcy": 0},  # Min dimensions
-                    30,  # Max tables
-                    True,  # Include system tables
-                    False,  # Include hidden fields
+                    30,  # qCellHeight
+                    True,  # qSyntheticMode
+                    False,  # qIncludeSysVars
                 ],
                 handle=app_handle,
             )
@@ -3081,9 +3126,9 @@ class QlikEngineAPI:
                 [
                     {"qcx": 1000, "qcy": 1000},  # Max dimensions
                     {"qcx": 0, "qcy": 0},  # Min dimensions
-                    50,  # Max tables
-                    False,  # Include system tables
-                    False,  # Include hidden fields
+                    50,  # qCellHeight
+                    False,  # qSyntheticMode
+                    False,  # qIncludeSysVars
                 ],
                 handle=app_handle,
             )


### PR DESCRIPTION
## Summary
- Fix: `ensure_app()` no longer trusts the requested `no_data` flag when caching whether an app connection has data — it now verifies Engine's own `qIsOpenedWithoutData` via `GetAppLayout` right after `OpenDoc`, retries once on mismatch, and raises `QlikEngineError` instead of silently returning a handle that later yields an empty data model from `GetTablesAndKeys`.
- Fix: corrected misleading inline comments on `GetTablesAndKeys` positional args (values unchanged).
- chore: bump version 1.7.0 -> 1.7.1 (pyproject.toml, __init__.py, .bumpversion.cfg, docs/installation.md pin), CHANGELOG entry.

## Test plan
- [x] `python -m pytest tests/` — 170 passed