### PR TITLE
Release v1.7.2 - surface COMMENT FIELD / COMMENT TABLE text

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.7.1
+current_version = 1.7.2
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.7.2] - 2026-07-31
+
+### Added
+- **Field and table comments are now returned.** Qlik keeps the business
+  description of a column in `qComment`, set by `COMMENT FIELD x WITH
+  '...'` / `COMMENT TABLE t WITH '...'` in the load script, and hands it
+  out in `GetTablesAndKeys` for every field and table. The server used to
+  drop it — `get_app_details` reported a hard-coded empty comment — so an
+  LLM had to infer a column's meaning from its name alone. Now
+  `get_app_details` puts a `comment` key on every table and field that
+  carries one, and `get_app_field` returns `field_comment` for the field
+  it lists. The key is omitted when the script sets no comment, so apps
+  without comments pay nothing in context size.
+- `QlikEngineAPI.get_field_description()` — thin wrapper over the Engine
+  `GetFieldDescription` method: name, comment, source tables, cardinality,
+  byte size for a single field, with no data page and no hypercube.
+  Returns `{}` for a field the model does not know.
+- `tests/test_field_comments.py` — covers comment propagation through
+  `get_fields`, `get_field_description` and the `get_app_details` payload,
+  including the "no comment set" case that must not emit the key.
+
 ## [1.7.1] - 2026-07-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ secrets). See [`docs/AUTH_JWT.md`](docs/AUTH_JWT.md) for the JWT setup.
 
 ## Key facts about the v1.7.0 line
 
+- **Column meanings, not just column names.** Fields and tables commented
+  in the load script (`COMMENT FIELD` / `COMMENT TABLE`) carry that text
+  into `get_app_details` as `comment`, and into `get_app_field` as
+  `field_comment`, so the model reads what a column means instead of
+  guessing from its name. Added in 1.7.2.
+
 - **Runs on both MCP SDK lines.** SDK 2.0 dropped `FastMCP`; the server
   now picks `MCPServer` (2.x) or `FastMCP` (1.x) at import time, so
   `mcp>=1.1.0,<3.0.0` all work. Both lines are covered by the test

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -28,7 +28,7 @@ categories. The lists below are a quick map only.
 |------|---------|
 | `get_about` | Qlik Sense server info: version, build, node type. Use to verify connectivity. |
 | `get_apps` | List apps with filters (`name`, `stream`, `published`) and pagination. `limit` capped at 50. |
-| `get_app_details` | App overview: metadata, full table list with row counts, full field list with `distinct_values`, plus a `warnings` array that flags huge fact tables and high-cardinality fields. Always call this before building a hypercube. |
+| `get_app_details` | App overview: metadata, full table list with row counts, full field list with `distinct_values`, plus a `warnings` array that flags huge fact tables and high-cardinality fields. Tables and fields that carry a `COMMENT TABLE` / `COMMENT FIELD` text from the load script also get a `comment` key — the business meaning of the column, absent when the script sets none. Always call this before building a hypercube. |
 
 ## Engine API
 
@@ -39,7 +39,7 @@ categories. The lists below are a quick map only.
 | `get_app_sheets` | List of sheets in the app, with title and description. |
 | `get_app_sheet_objects` | List of objects on a specific sheet, with `object_id`, `object_type`, `object_description`. |
 | `get_app_object` | Full layout of one specific object via `GetObject` + `GetLayout`. Reverse-engineers an existing chart. |
-| `get_app_field` | Distinct values of one field with pagination and wildcard search. Falls back to a single-dimension hypercube if the underlying `ListObject` returns nothing. |
+| `get_app_field` | Distinct values of one field with pagination and wildcard search. Falls back to a single-dimension hypercube if the underlying `ListObject` returns nothing. Adds `field_comment` when the load script commented that field. |
 | `engine_get_field_range` | Lightning-fast bounds for one field: count distinct, min, max. Implemented as a measures-only hypercube — runs in seconds on any table size. Prefer this over `get_app_field_statistics`. |
 | `get_app_field_statistics` | Field statistics via a measures-only hypercube. Defaults to **light** mode (count distinct, count, non-null count, min, max, null %, completeness). Pass `full=true` to also compute avg / sum / median / mode / stdev — slow on big fact tables and meaningless for date/text fields. |
 | `engine_create_hypercube` | Build an arbitrary `GROUP BY` hypercube — the main data-analysis tool. Supports ranking directly: `sort_by` (measure label / measure expression / dimension field) + `sort_order` (`desc` / `asc`) + `limit`. Rows with a NULL dimension value (Qlik's `"-"`) are dropped by default — pass `exclude_null_dimensions=false` to keep them. Hard limits: `limit <= 5000`, `columns * limit <= 9900`. Read the full docstring — it covers set-analysis patterns, the no-expression-in-dimension rule and the session limit. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qlik-sense-mcp-server"
-version = "1.7.1"
+version = "1.7.2"
 description = "MCP Server for Qlik Sense Enterprise APIs"
 readme = "README.md"
 license = {text = "MIT"}

--- a/qlik_sense_mcp_server/__init__.py
+++ b/qlik_sense_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Qlik Sense MCP Server for Enterprise APIs."""
 
-__version__ = "1.7.1"
+__version__ = "1.7.2"

--- a/qlik_sense_mcp_server/engine_api.py
+++ b/qlik_sense_mcp_server/engine_api.py
@@ -989,12 +989,18 @@ class QlikEngineAPI:
             if "qtr" in result:
                 for table in result["qtr"]:
                     table_name = table.get("qName", "Unknown")
+                    table_comment = table.get("qComment", "")
 
                     if "qFields" in table:
                         for field in table["qFields"]:
                             field_info = {
                                 "field_name": field.get("qName", ""),
                                 "table_name": table_name,
+                                # COMMENT FIELD / COMMENT TABLE from the load
+                                # script — the only human description a field
+                                # carries in the data model.
+                                "comment": field.get("qComment", ""),
+                                "table_comment": table_comment,
                                 "data_type": field.get("qType", ""),
                                 "is_key": field.get("qIsKey", False),
                                 "is_system": field.get("qIsSystem", False),
@@ -1950,6 +1956,33 @@ class QlikEngineAPI:
 
         except Exception as e:
             return {"error": str(e), "details": "Error in get_table_data method"}
+
+    def get_field_description(self, app_handle: int, field_name: str) -> Dict[str, Any]:
+        """Describe one field via `GetFieldDescription`.
+
+        The only Engine call that returns a single field's `COMMENT FIELD`
+        text without walking the whole data model. Cheap — no hypercube, no
+        data page. Returns `{}` when the field is unknown to the model
+        (Engine answers "Invalid parameters" in that case).
+        """
+        try:
+            result = self.send_request(
+                "GetFieldDescription", [field_name], handle=app_handle
+            )
+            info = result.get("qReturn", {}) or {}
+            return {
+                "name": info.get("qName", field_name),
+                "comment": info.get("qComment", ""),
+                "src_tables": info.get("qSrcTables", []),
+                "cardinal": info.get("qCardinal", 0),
+                "total_count": info.get("qTotalCount", 0),
+                "is_numeric": info.get("qIsNumeric", False),
+                "tags": info.get("qTags", []),
+                "byte_size": info.get("qByteSize", 0),
+            }
+        except Exception as e:
+            logger.debug("GetFieldDescription(%s) failed: %s", field_name, e)
+            return {}
 
     def get_field_values(
         self,
@@ -2942,7 +2975,7 @@ class QlikEngineAPI:
                         "is_locked": False,
                         "always_one_selected": False,
                         "is_numeric": "numeric" in field.get("tags", []),
-                        "comment": "",
+                        "comment": field.get("comment", ""),
                         "tags": field.get("tags", []),
                         "byte_size": 0,  # Not available via Engine API
                         "hash": "",  # Not available via Engine API
@@ -3141,6 +3174,7 @@ class QlikEngineAPI:
                 for field in table.get("qFields", []):
                     field_info = {
                         "name": field.get("qName", ""),
+                        "comment": field.get("qComment", ""),
                         "data_type": self._determine_data_type(field.get("qTags", [])),
                         "total_rows": field.get("qnRows", 0),
                         "distinct_values": field.get("qnTotalDistinctValues", 0),
@@ -3155,6 +3189,7 @@ class QlikEngineAPI:
 
                 table_info = {
                     "name": table_name,
+                    "comment": table.get("qComment", ""),
                     "total_rows": table.get("qNoOfRows", 0),
                     "field_count": len(table_fields),
                     "fields": table_fields,

--- a/qlik_sense_mcp_server/server.py
+++ b/qlik_sense_mcp_server/server.py
@@ -491,9 +491,12 @@ def get_app_details(app_id: Optional[str] = None, name: Optional[str] = None) ->
         JSON with `metainfo` (app_id, name, description, stream, modified_dttm,
         reload_dttm), `tables` (summary of each table), and `fields` (every
         non-system, non-hidden field with its table, is_key flag, distinct_values,
-        row count, and tags). Use the `fields` list to check field names and
-        cardinalities before writing hypercube dimensions.
-    
+        row count, and tags). Tables and fields carrying a `COMMENT TABLE` /
+        `COMMENT FIELD` text from the load script also get a `comment` key —
+        that is the business description of the column, so read it before
+        guessing a field's meaning from its name. The key is absent when the
+        script sets no comment.
+
     Example:
         Call: {"app_id": "a1b2c3d4-1111-2222-3333-444455556666"}
         Returns: {"tool_call_seconds": 2.84,
@@ -502,10 +505,11 @@ def get_app_details(app_id: Optional[str] = None, name: Optional[str] = None) ->
                                "reload_dttm": "2026-07-27T03:00:00.000Z"},
                   "warnings": ["Large fact table(s) detected ..."],
                   "tables": [{"name": "Orders", "fields_count": 12,
-                              "rows": 91028794}],
+                              "rows": 91028794, "comment": "Order facts"}],
                   "fields": [{"name": "Amount", "table": "Orders",
                               "is_key": false, "distinct_values": 9797173,
-                              "rows": 91028794, "tags": ["$numeric"]}],
+                              "rows": 91028794, "tags": ["$numeric"],
+                              "comment": "Order amount, net of refunds"}],
                   "tables_count": 8, "fields_count": 120}
 
     Read `warnings` first — it tells you which tables are too big to
@@ -569,21 +573,31 @@ def get_app_details(app_id: Optional[str] = None, name: Optional[str] = None) ->
                 continue
             tname = f.get("table_name", "")
             table_map.setdefault(tname, []).append(f)
-            fields.append({
+            entry = {
                 "name": f.get("field_name", ""),
                 "table": tname,
                 "is_key": f.get("is_key", False),
                 "distinct_values": f.get("distinct_values", 0),
                 "rows": f.get("rows_count", 0),
                 "tags": f.get("tags", []),
-            })
+            }
+            # COMMENT FIELD text, when the load script sets one. Emitted only
+            # when non-empty: most apps comment a handful of fields, and an
+            # empty key on every field is pure noise in the LLM context.
+            if f.get("comment"):
+                entry["comment"] = f["comment"]
+            fields.append(entry)
         for tname, tfields in table_map.items():
             rows = max((f.get("rows_count", 0) for f in tfields), default=0)
-            tables.append({
+            entry = {
                 "name": tname,
                 "fields_count": len(tfields),
                 "rows": rows,
-            })
+            }
+            comment = next((f.get("table_comment") for f in tfields if f.get("table_comment")), "")
+            if comment:
+                entry["comment"] = comment
+            tables.append(entry)
 
     # Build performance warnings: huge tables / high-cardinality keys are
     # the main source of hypercube timeouts on this app. Surface them so
@@ -1175,12 +1189,15 @@ def get_app_field(
     Returns:
         JSON `{ "field_values": ["val1", "val2", ...] }` — plain list after
         filtering and pagination. Order is by frequency descending on the
-        Qlik side.
-    
+        Qlik side. When the load script attached a `COMMENT FIELD` text to
+        this field, the response also carries `field_comment` with that
+        business description.
+
     Example (see what values a dimension holds):
         Call: {"app_id": "a1b2...", "field_name": "Region", "limit": 5}
         Returns: {"tool_call_seconds": 0.7,
-                  "field_values": ["North", "South", "West"]}
+                  "field_values": ["North", "South", "West"],
+                  "field_comment": "Sales region of the client"}
 
     Example (wildcard search; `fallback_used` appears when the fast
     ListObject path returned nothing and a hypercube was used instead):
@@ -1218,6 +1235,11 @@ def get_app_field(
                     filtered.append(cell_text)
             values = filtered
         out: Dict[str, Any] = {"field_values": values[off:off + lim]}
+        # COMMENT FIELD text of this very field, when the script sets one —
+        # one cheap GetFieldDescription call, no data page involved.
+        comment = engine_api.get_field_description(app_handle, field_name).get("comment")
+        if comment:
+            out["field_comment"] = comment
         # Surface internal hints from get_field_values so the LLM knows
         # whether the result came from the fast ListObject path or from the
         # heavier hypercube fallback, and whether anything looked off.

--- a/tests/test_field_comments.py
+++ b/tests/test_field_comments.py
@@ -8,6 +8,7 @@ meant from its name.
 """
 
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -96,45 +97,55 @@ class TestGetFieldDescription:
         assert api.get_field_description(1, "nope") == {}
 
 
+FIELDS_PAYLOAD = {
+    "fields": [
+        {
+            "field_name": "Amount",
+            "table_name": "Orders",
+            "comment": "Order amount, net of refunds",
+            "table_comment": "Order facts",
+            "rows_count": 2,
+            "distinct_values": 2,
+            "tags": ["$numeric"],
+        },
+        {
+            "field_name": "OrderId",
+            "table_name": "Orders",
+            "comment": "",
+            "table_comment": "Order facts",
+            "rows_count": 2,
+            "distinct_values": 2,
+            "tags": ["$integer"],
+        },
+    ]
+}
+
+
 class TestAppDetailsPayload:
     """`get_app_details` emits `comment` only where the script set one."""
 
     @pytest.fixture(autouse=True)
     def _stub_apis(self, monkeypatch):
+        # Without Qlik env vars the module-level clients are None (that is
+        # how CI runs), so replace the whole client objects rather than
+        # patching attributes on them.
         monkeypatch.setattr(srv, "_check", lambda: None)
         monkeypatch.setattr(
-            srv.repo_api,
-            "get_app_by_id",
-            lambda app_id: {"id": app_id, "name": "App", "published": False},
-            raising=False,
+            srv,
+            "repo_api",
+            SimpleNamespace(
+                get_app_by_id=lambda app_id: {
+                    "id": app_id, "name": "App", "published": False
+                }
+            ),
         )
-        monkeypatch.setattr(srv.engine_api, "ensure_app", lambda *a, **kw: 1, raising=False)
         monkeypatch.setattr(
-            srv.engine_api,
-            "get_fields",
-            lambda handle: {
-                "fields": [
-                    {
-                        "field_name": "Amount",
-                        "table_name": "Orders",
-                        "comment": "Order amount, net of refunds",
-                        "table_comment": "Order facts",
-                        "rows_count": 2,
-                        "distinct_values": 2,
-                        "tags": ["$numeric"],
-                    },
-                    {
-                        "field_name": "OrderId",
-                        "table_name": "Orders",
-                        "comment": "",
-                        "table_comment": "Order facts",
-                        "rows_count": 2,
-                        "distinct_values": 2,
-                        "tags": ["$integer"],
-                    },
-                ]
-            },
-            raising=False,
+            srv,
+            "engine_api",
+            SimpleNamespace(
+                ensure_app=lambda *a, **kw: 1,
+                get_fields=lambda handle: FIELDS_PAYLOAD,
+            ),
         )
 
     def _details(self):

--- a/tests/test_field_comments.py
+++ b/tests/test_field_comments.py
@@ -1,0 +1,153 @@
+"""Tests for COMMENT FIELD / COMMENT TABLE propagation (since v1.7.2).
+
+Qlik carries a field's business description in `qComment` — set by
+`COMMENT FIELD x WITH '...'` in the load script — and returns it both in
+`GetTablesAndKeys` (per field and per table) and in `GetFieldDescription`.
+Before v1.7.2 the server dropped it, so an LLM had to guess what a column
+meant from its name.
+"""
+
+import json
+
+import pytest
+
+from qlik_sense_mcp_server.engine_api import QlikEngineAPI
+from qlik_sense_mcp_server import server as srv
+
+
+TABLES_AND_KEYS = {
+    "qtr": [
+        {
+            "qName": "Orders",
+            "qComment": "Order facts",
+            "qNoOfRows": 2,
+            "qFields": [
+                {
+                    "qName": "Amount",
+                    "qComment": "Order amount, net of refunds",
+                    "qnRows": 2,
+                    "qnTotalDistinctValues": 2,
+                    "qTags": ["$numeric"],
+                },
+                {
+                    "qName": "OrderId",
+                    "qnRows": 2,
+                    "qnTotalDistinctValues": 2,
+                    "qTags": ["$integer"],
+                },
+            ],
+        }
+    ]
+}
+
+
+@pytest.fixture
+def engine(monkeypatch):
+    api = QlikEngineAPI.__new__(QlikEngineAPI)
+    monkeypatch.setattr(
+        api, "send_request", lambda *a, **kw: TABLES_AND_KEYS, raising=False
+    )
+    return api
+
+
+class TestGetFields:
+    def test_field_comment_is_kept(self, engine):
+        fields = engine.get_fields(app_handle=1)["fields"]
+        by_name = {f["field_name"]: f for f in fields}
+        assert by_name["Amount"]["comment"] == "Order amount, net of refunds"
+
+    def test_missing_comment_is_empty_string(self, engine):
+        fields = engine.get_fields(app_handle=1)["fields"]
+        by_name = {f["field_name"]: f for f in fields}
+        assert by_name["OrderId"]["comment"] == ""
+
+    def test_table_comment_travels_with_every_field(self, engine):
+        fields = engine.get_fields(app_handle=1)["fields"]
+        assert {f["table_comment"] for f in fields} == {"Order facts"}
+
+
+class TestGetFieldDescription:
+    def test_maps_qcomment(self, monkeypatch):
+        api = QlikEngineAPI.__new__(QlikEngineAPI)
+        payload = {
+            "qReturn": {
+                "qName": "Amount",
+                "qComment": "Order amount, net of refunds",
+                "qSrcTables": ["Orders"],
+                "qCardinal": 2,
+                "qTotalCount": 2,
+                "qIsNumeric": True,
+                "qTags": ["$numeric"],
+                "qByteSize": 22,
+            }
+        }
+        monkeypatch.setattr(api, "send_request", lambda *a, **kw: payload, raising=False)
+        described = api.get_field_description(1, "Amount")
+        assert described["comment"] == "Order amount, net of refunds"
+        assert described["src_tables"] == ["Orders"]
+
+    def test_unknown_field_returns_empty_dict(self, monkeypatch):
+        api = QlikEngineAPI.__new__(QlikEngineAPI)
+
+        def boom(*a, **kw):
+            raise RuntimeError("Invalid parameters")
+
+        monkeypatch.setattr(api, "send_request", boom, raising=False)
+        assert api.get_field_description(1, "nope") == {}
+
+
+class TestAppDetailsPayload:
+    """`get_app_details` emits `comment` only where the script set one."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_apis(self, monkeypatch):
+        monkeypatch.setattr(srv, "_check", lambda: None)
+        monkeypatch.setattr(
+            srv.repo_api,
+            "get_app_by_id",
+            lambda app_id: {"id": app_id, "name": "App", "published": False},
+            raising=False,
+        )
+        monkeypatch.setattr(srv.engine_api, "ensure_app", lambda *a, **kw: 1, raising=False)
+        monkeypatch.setattr(
+            srv.engine_api,
+            "get_fields",
+            lambda handle: {
+                "fields": [
+                    {
+                        "field_name": "Amount",
+                        "table_name": "Orders",
+                        "comment": "Order amount, net of refunds",
+                        "table_comment": "Order facts",
+                        "rows_count": 2,
+                        "distinct_values": 2,
+                        "tags": ["$numeric"],
+                    },
+                    {
+                        "field_name": "OrderId",
+                        "table_name": "Orders",
+                        "comment": "",
+                        "table_comment": "Order facts",
+                        "rows_count": 2,
+                        "distinct_values": 2,
+                        "tags": ["$integer"],
+                    },
+                ]
+            },
+            raising=False,
+        )
+
+    def _details(self):
+        return json.loads(srv.get_app_details(app_id="a1b2c3d4-1111-2222-3333-444455556666"))
+
+    def test_commented_field_carries_comment(self):
+        fields = {f["name"]: f for f in self._details()["fields"]}
+        assert fields["Amount"]["comment"] == "Order amount, net of refunds"
+
+    def test_uncommented_field_has_no_comment_key(self):
+        fields = {f["name"]: f for f in self._details()["fields"]}
+        assert "comment" not in fields["OrderId"]
+
+    def test_table_comment_is_reported_once(self):
+        tables = self._details()["tables"]
+        assert [t["comment"] for t in tables] == ["Order facts"]


### PR DESCRIPTION
Qlik keeps a column's business description in `qComment` (`COMMENT FIELD x WITH '...'` in the load script) and returns it in `GetTablesAndKeys`. The server dropped it, so an LLM had to guess a column's meaning from its name.

- `get_app_details` emits `comment` on tables and fields that have one, omits the key otherwise
- `get_app_field` returns `field_comment`
- new `QlikEngineAPI.get_field_description()` over the Engine `GetFieldDescription` method
- `tests/test_field_comments.py`, 178 tests pass

Verified against a live Qlik cluster on both a probe app and a 114-field production report.