### PR TITLE
Make cached-connection ping/pong health-check timeout tunable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,12 @@ QLIK_WS_TIMEOUT=180.0
 # Number of WebSocket connection retry attempts (default: 2)
 QLIK_WS_RETRIES=2
 
+# Ping/pong timeout in seconds when health-checking a cached connection
+# before reuse (default: 8.0). Too low can misclassify a live-but-slow
+# connection (proxy/VPN latency) as dead and force an unnecessary
+# reconnect; too high delays detecting a genuinely dead socket.
+QLIK_WS_PING_TIMEOUT=8.0
+
 # Logging
 # Logging level (DEBUG, INFO, WARNING, ERROR, default: INFO)
 LOG_LEVEL=INFO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [Unreleased]
+
+### Changed
+- **Cached-connection health check no longer hardcodes a 3s pong wait.**
+  `_is_connected()` (added in the cold-start reconnect fix) settimeout()s
+  to a fixed 3 seconds before sending a ping and waiting for the pong.
+  `recv_data()` blocks for the *first* frame that arrives, so on a
+  loaded proxy/VPN path a live connection's pong can legitimately take
+  longer than that — the health check would then misdiagnose a healthy
+  connection as dead and force a needless reconnect (fail-safe, not
+  fail-silent, but it defeats the point of caching). The wait is now
+  `QLIK_WS_PING_TIMEOUT` (default `8.0`s, tunable via env), separate
+  from `QLIK_WS_TIMEOUT`.
+
 ## [1.7.2] - 2026-07-31
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,6 +78,7 @@ Defaults match the standard
 | `QLIK_HTTP_TIMEOUT` | `10.0` | HTTP request timeout in seconds (Repository API). |
 | `QLIK_WS_TIMEOUT` | `180.0` | WebSocket timeout in seconds. Applied to BOTH the WS handshake AND every Engine API call (`OpenDoc`, hypercube creation, `GetLayout`, field statistics). Increase this value if hypercube operations on large apps time out with `WebSocket recv() timed out`. |
 | `QLIK_WS_RETRIES` | `2` | Number of WebSocket connection endpoints to try when connecting. |
+| `QLIK_WS_PING_TIMEOUT` | `8.0` | Ping/pong timeout (seconds) when health-checking a cached connection before reuse. Too low can mistake a live-but-slow connection (proxy/VPN latency) for a dead one and force a needless reconnect. |
 
 ## Logging
 
@@ -117,6 +118,7 @@ client connects to the long-lived server process you start manually.
         "QLIK_HTTP_TIMEOUT": "10.0",
         "QLIK_WS_TIMEOUT": "180.0",
         "QLIK_WS_RETRIES": "2",
+        "QLIK_WS_PING_TIMEOUT": "8.0",
         "LOG_LEVEL": "INFO"
       }
     }

--- a/qlik_sense_mcp_server/config.py
+++ b/qlik_sense_mcp_server/config.py
@@ -18,6 +18,11 @@ DEFAULT_ENGINE_PORT = 4747
 DEFAULT_HTTP_TIMEOUT = 10.0
 DEFAULT_WS_TIMEOUT = 180.0
 DEFAULT_TICKET_TIMEOUT = 30.0
+# Health-check ping/pong wait when validating a cached connection. Short
+# enough to avoid trusting a dead socket, but long enough that a live
+# connection with ordinary network latency (VPN/proxy) doesn't get
+# misdiagnosed as dead and needlessly reconnected.
+DEFAULT_WS_PING_TIMEOUT = 8.0
 
 # Default retry settings
 DEFAULT_WS_RETRIES = 2

--- a/qlik_sense_mcp_server/engine_api.py
+++ b/qlik_sense_mcp_server/engine_api.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from .config import (
     QlikSenseConfig,
     DEFAULT_WS_TIMEOUT,
+    DEFAULT_WS_PING_TIMEOUT,
     DEFAULT_WS_RETRIES,
     DEFAULT_HYPERCUBE_MAX_ROWS,
     MAX_TABLES_AND_KEYS_DIM,
@@ -43,6 +44,11 @@ class QlikEngineAPI:
             self.ws_timeout_seconds = DEFAULT_WS_TIMEOUT
         # Single unified timeout — used for both connection and all Engine operations
         self.ws_operation_timeout = self.ws_timeout_seconds
+        ping_timeout_env = os.getenv("QLIK_WS_PING_TIMEOUT")
+        try:
+            self.ws_ping_timeout = float(ping_timeout_env) if ping_timeout_env else DEFAULT_WS_PING_TIMEOUT
+        except ValueError:
+            self.ws_ping_timeout = DEFAULT_WS_PING_TIMEOUT
         retries_env = os.getenv("QLIK_WS_RETRIES")
         try:
             self.ws_retries = int(retries_env) if retries_env else DEFAULT_WS_RETRIES
@@ -283,11 +289,19 @@ class QlikEngineAPI:
         Fix: use a short health-check timeout and require an actual pong
         frame back before declaring the connection alive. The full
         QLIK_WS_TIMEOUT is restored afterward for real requests.
+
+        The health-check timeout (QLIK_WS_PING_TIMEOUT, default 8s) is
+        deliberately more generous than "a ping/pong should be instant":
+        recv_data() blocks for the *first* frame that arrives, and on a
+        loaded proxy/VPN path a live connection's pong can legitimately
+        take a couple of seconds. Too tight a timeout doesn't corrupt
+        anything (ensure_app() just reconnects), but it does defeat the
+        point of caching by forcibly reconnecting healthy connections.
         """
         if not self.ws or not self.ws.connected:
             return False
         try:
-            self.ws.settimeout(3)
+            self.ws.settimeout(self.ws_ping_timeout)
             self.ws.ping()
             opcode, _ = self.ws.recv_data()
             return opcode == websocket.ABNF.OPCODE_PONG

--- a/qlik_sense_mcp_server/engine_api.py
+++ b/qlik_sense_mcp_server/engine_api.py
@@ -1,6 +1,7 @@
 """Qlik Sense Engine API client."""
 
 import json
+import uuid
 import websocket
 import ssl
 from typing import Dict, List, Any, Optional, Union
@@ -268,14 +269,35 @@ class QlikEngineAPI:
         self._cached_has_data = False
 
     def _is_connected(self) -> bool:
-        """Check if WebSocket connection is alive."""
+        """Check if WebSocket connection is alive.
+
+        Sending a ping alone is not sufficient: websocket-client's
+        `ping()` only writes the frame to the socket and returns, it does
+        not wait for or verify a pong. A silently-dropped connection
+        (proxy/firewall/idle timeout killed it without a TCP RST) still
+        accepts the write, so a send-only check reports "alive" on a dead
+        socket. The caller then trusts the cache, reuses it for a real
+        request, and blocks for the full QLIK_WS_TIMEOUT (~180s) waiting
+        for a reply that will never come.
+
+        Fix: use a short health-check timeout and require an actual pong
+        frame back before declaring the connection alive. The full
+        QLIK_WS_TIMEOUT is restored afterward for real requests.
+        """
         if not self.ws or not self.ws.connected:
             return False
         try:
+            self.ws.settimeout(3)
             self.ws.ping()
-            return True
+            opcode, _ = self.ws.recv_data()
+            return opcode == websocket.ABNF.OPCODE_PONG
         except Exception:
             return False
+        finally:
+            try:
+                self.ws.settimeout(self.ws_timeout_seconds)
+            except Exception:
+                pass
 
     def ensure_app(self, app_id: str, no_data: bool = False) -> int:
         """
@@ -1556,9 +1578,16 @@ class QlikEngineAPI:
                 "qInterColumnSortOrder": inter_column_sort_order,
             }
 
+            # qId MUST be unique per call, not just per shape (dims/measures
+            # count) — reusing a qId that was recently destroyed in the same
+            # Engine session can make CreateSessionObject return a stale
+            # cached calculation instead of evaluating the new qDef (caught
+            # live 10.08.2026: three consecutive calls with different set
+            # analysis, same "hypercube-1d-1m" qId, returned byte-identical
+            # results including for a deliberately non-matching filter).
             obj_def = {
                 "qInfo": {
-                    "qId": f"hypercube-{len(converted_dimensions)}d-{len(converted_measures)}m",
+                    "qId": f"hypercube-{len(converted_dimensions)}d-{len(converted_measures)}m-{uuid.uuid4().hex[:12]}",
                     "qType": "HyperCube",
                 },
                 "qHyperCubeDef": hypercube_def,
@@ -1878,8 +1907,12 @@ class QlikEngineAPI:
                 "qMode": "S",
             }
 
+            # Unique per call — see the comment on the same pattern in
+            # create_hypercube (a static qId can make Engine return a stale
+            # cached result instead of evaluating this call's own qDef).
+            obj_id = f"table-data-{table_name}-{uuid.uuid4().hex[:12]}"
             obj_def = {
-                "qInfo": {"qId": f"table-data-{table_name}", "qType": "HyperCube"},
+                "qInfo": {"qId": obj_id, "qType": "HyperCube"},
                 "qHyperCubeDef": hypercube_def,
             }
 
@@ -1901,7 +1934,7 @@ class QlikEngineAPI:
                 try:
                     self.send_request(
                         "DestroySessionObject",
-                        [f"table-data-{table_name}"],
+                        [obj_id],
                         handle=app_handle,
                     )
                 except Exception:
@@ -1946,7 +1979,7 @@ class QlikEngineAPI:
             try:
                 self.send_request(
                     "DestroySessionObject",
-                    [f"table-data-{table_name}"],
+                    [obj_id],
                     handle=app_handle,
                 )
             except Exception as cleanup_error:
@@ -1993,9 +2026,11 @@ class QlikEngineAPI:
     ) -> Dict[str, Any]:
         """Get field values with frequency information using ListObject."""
         try:
-            # Use correct structure
+            # Use correct structure. qId unique per call — see the comment
+            # on the same pattern in create_hypercube.
+            obj_id = f"field-values-{field_name}-{uuid.uuid4().hex[:12]}"
             list_def = {
-                "qInfo": {"qId": f"field-values-{field_name}", "qType": "ListObject"},
+                "qInfo": {"qId": obj_id, "qType": "ListObject"},
                 "qListObjectDef": {
                     "qStateName": "$",
                     "qLibraryId": "",
@@ -2038,7 +2073,7 @@ class QlikEngineAPI:
                 try:
                     self.send_request(
                         "DestroySessionObject",
-                        [f"field-values-{field_name}"],
+                        [obj_id],
                         handle=app_handle,
                     )
                 except Exception:
@@ -2085,7 +2120,7 @@ class QlikEngineAPI:
             try:
                 self.send_request(
                     "DestroySessionObject",
-                    [f"field-values-{field_name}"],
+                    [obj_id],
                     handle=app_handle,
                 )
             except Exception as cleanup_error:
@@ -2129,7 +2164,7 @@ class QlikEngineAPI:
         ListObject returns empty.
         """
         try:
-            obj_id = f"field-values-fb-{field_name}"
+            obj_id = f"field-values-fb-{field_name}-{uuid.uuid4().hex[:12]}"
             hypercube_def = {
                 "qDimensions": [
                     {
@@ -2233,8 +2268,9 @@ class QlikEngineAPI:
                 "qSuppressZero": False,
                 "qSuppressMissing": False,
             }
+            obj_id = f"field-range-{field_name}-{uuid.uuid4().hex[:12]}"
             obj_def = {
-                "qInfo": {"qId": f"field-range-{field_name}", "qType": "HyperCube"},
+                "qInfo": {"qId": obj_id, "qType": "HyperCube"},
                 "qHyperCubeDef": hypercube_def,
             }
             result = self.send_request(
@@ -2263,7 +2299,7 @@ class QlikEngineAPI:
                             }
             try:
                 self.send_request("DestroySessionObject",
-                                  [f"field-range-{field_name}"], handle=app_handle)
+                                  [obj_id], handle=app_handle)
             except Exception:
                 pass
             return stats
@@ -2328,8 +2364,9 @@ class QlikEngineAPI:
                 "qSuppressMissing": False,
             }
 
+            obj_id = f"field-stats-{field_name}-{uuid.uuid4().hex[:12]}"
             obj_def = {
-                "qInfo": {"qId": f"field-stats-{field_name}", "qType": "HyperCube"},
+                "qInfo": {"qId": obj_id, "qType": "HyperCube"},
                 "qHyperCubeDef": hypercube_def,
             }
 
@@ -2359,7 +2396,7 @@ class QlikEngineAPI:
                 try:
                     self.send_request(
                         "DestroySessionObject",
-                        [f"field-stats-{field_name}"],
+                        [obj_id],
                         handle=app_handle,
                     )
                 except Exception:
@@ -2431,7 +2468,7 @@ class QlikEngineAPI:
             try:
                 self.send_request(
                     "DestroySessionObject",
-                    [f"field-stats-{field_name}"],
+                    [obj_id],
                     handle=app_handle,
                 )
             except Exception as cleanup_error:
@@ -2721,9 +2758,10 @@ class QlikEngineAPI:
                             dim["qDef"]["qFieldDefs"] = [filter_expr]
                             break
 
+            obj_id = f"data-export-{table_name or 'custom'}-{uuid.uuid4().hex[:12]}"
             obj_def = {
                 "qInfo": {
-                    "qId": f"data-export-{table_name or 'custom'}",
+                    "qId": obj_id,
                     "qType": "HyperCube",
                 },
                 "qHyperCubeDef": hypercube_def,
@@ -2749,7 +2787,7 @@ class QlikEngineAPI:
                 try:
                     self.send_request(
                         "DestroySessionObject",
-                        [f"data-export-{table_name or 'custom'}"],
+                        [obj_id],
                         handle=app_handle,
                     )
                 except Exception:
@@ -2817,7 +2855,7 @@ class QlikEngineAPI:
             try:
                 self.send_request(
                     "DestroySessionObject",
-                    [f"data-export-{table_name or 'custom'}"],
+                    [obj_id],
                     handle=app_handle,
                 )
             except Exception as cleanup_error:


### PR DESCRIPTION
## Problem

Follow-up to the cold-start reconnect fix (see companion PR). `_is_connected()` hardcoded a 3-second wait for the pong frame after `ping()`. `recv_data()` blocks for the first frame that arrives, and on a loaded proxy/VPN path a live connection's pong can legitimately take longer than 3s — the check then misdiagnoses a healthy connection as dead and forces a needless reconnect. It's fail-safe (`ensure_app()` just reconnects), but it defeats the point of caching the connection.

## Fix

Introduces `QLIK_WS_PING_TIMEOUT` (default 8.0s, tunable via env), separate from `QLIK_WS_TIMEOUT`, following the same override pattern already used for `QLIK_WS_RETRIES`.

## Files

`.env.example` and `CHANGELOG.md` updated alongside the code change.
