### PR TITLE
Add pipelined batch requests, use them in _get_sheet_objects_detailed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,12 @@ QLIK_WS_TIMEOUT=180.0
 # Number of WebSocket connection retry attempts (default: 2)
 QLIK_WS_RETRIES=2
 
+# Ping/pong timeout in seconds when health-checking a cached connection
+# before reuse (default: 8.0). Too low can misclassify a live-but-slow
+# connection (proxy/VPN latency) as dead and force an unnecessary
+# reconnect; too high delays detecting a genuinely dead socket.
+QLIK_WS_PING_TIMEOUT=8.0
+
 # Logging
 # Logging level (DEBUG, INFO, WARNING, ERROR, default: INFO)
 LOG_LEVEL=INFO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Added
+- **`QlikEngineAPI.send_requests_pipelined()`** — sends a batch of
+  independent JSON-RPC requests back-to-back without waiting for each
+  response before sending the next, then matches responses back to
+  requests by `id` (the Engine's own protocol contract explicitly
+  supports out-of-order responses for this reason — see "Let's Dissect
+  the Qlik Engine API - Part 1: RPC Basics", Qlik Community). Does not
+  touch `send_request()`, which is unchanged and still used everywhere
+  else. `raise_on_error=False` returns per-item `Exception` instances
+  instead of aborting the whole batch, so a caller can keep the
+  successful results from a batch where one item failed.
+- `_get_sheet_objects_detailed()` now uses two pipelined batches (all
+  `GetObject` calls, then all `GetLayout` calls) instead of one
+  `GetObject`+`GetLayout` round-trip per sheet object — a sheet with N
+  objects used to serialize 2N round-trips, now costs 2 regardless of N.
+  Per-object error isolation is unchanged: one bad object is skipped,
+  not the whole sheet.
+- `tests/test_pipelining.py` — covers out-of-order response matching,
+  per-item error handling (`raise_on_error` both ways), stray-notification
+  frames mid-batch, and that `_get_sheet_objects_detailed()` issues
+  exactly 2 batched calls regardless of child-object count.
+
+**Not yet live-verified against a real Qlik Engine** — only unit-tested
+against a fake socket (187/187 tests pass). Whether this produces a
+measurable wall-clock improvement depends on how much of the observed
+latency is network round-trip vs. Engine-side per-request cost, which
+differs by deployment; a live before/after timing comparison on
+`_get_sheet_objects_detailed()` against a real app is the natural
+follow-up before leaning on this for anything performance-critical.
+
 ### Changed
 - **Cached-connection health check no longer hardcodes a 3s pong wait.**
   `_is_connected()` (added in the cold-start reconnect fix) settimeout()s

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [Unreleased]
+
+### Changed
+- **Cached-connection health check no longer hardcodes a 3s pong wait.**
+  `_is_connected()` (added in the cold-start reconnect fix) settimeout()s
+  to a fixed 3 seconds before sending a ping and waiting for the pong.
+  `recv_data()` blocks for the *first* frame that arrives, so on a
+  loaded proxy/VPN path a live connection's pong can legitimately take
+  longer than that — the health check would then misdiagnose a healthy
+  connection as dead and force a needless reconnect (fail-safe, not
+  fail-silent, but it defeats the point of caching). The wait is now
+  `QLIK_WS_PING_TIMEOUT` (default `8.0`s, tunable via env), separate
+  from `QLIK_WS_TIMEOUT`.
+
 ## [1.7.2] - 2026-07-31
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,6 +78,7 @@ Defaults match the standard
 | `QLIK_HTTP_TIMEOUT` | `10.0` | HTTP request timeout in seconds (Repository API). |
 | `QLIK_WS_TIMEOUT` | `180.0` | WebSocket timeout in seconds. Applied to BOTH the WS handshake AND every Engine API call (`OpenDoc`, hypercube creation, `GetLayout`, field statistics). Increase this value if hypercube operations on large apps time out with `WebSocket recv() timed out`. |
 | `QLIK_WS_RETRIES` | `2` | Number of WebSocket connection endpoints to try when connecting. |
+| `QLIK_WS_PING_TIMEOUT` | `8.0` | Ping/pong timeout (seconds) when health-checking a cached connection before reuse. Too low can mistake a live-but-slow connection (proxy/VPN latency) for a dead one and force a needless reconnect. |
 
 ## Logging
 
@@ -117,6 +118,7 @@ client connects to the long-lived server process you start manually.
         "QLIK_HTTP_TIMEOUT": "10.0",
         "QLIK_WS_TIMEOUT": "180.0",
         "QLIK_WS_RETRIES": "2",
+        "QLIK_WS_PING_TIMEOUT": "8.0",
         "LOG_LEVEL": "INFO"
       }
     }

--- a/qlik_sense_mcp_server/config.py
+++ b/qlik_sense_mcp_server/config.py
@@ -18,6 +18,11 @@ DEFAULT_ENGINE_PORT = 4747
 DEFAULT_HTTP_TIMEOUT = 10.0
 DEFAULT_WS_TIMEOUT = 180.0
 DEFAULT_TICKET_TIMEOUT = 30.0
+# Health-check ping/pong wait when validating a cached connection. Short
+# enough to avoid trusting a dead socket, but long enough that a live
+# connection with ordinary network latency (VPN/proxy) doesn't get
+# misdiagnosed as dead and needlessly reconnected.
+DEFAULT_WS_PING_TIMEOUT = 8.0
 
 # Default retry settings
 DEFAULT_WS_RETRIES = 2

--- a/qlik_sense_mcp_server/engine_api.py
+++ b/qlik_sense_mcp_server/engine_api.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from .config import (
     QlikSenseConfig,
     DEFAULT_WS_TIMEOUT,
+    DEFAULT_WS_PING_TIMEOUT,
     DEFAULT_WS_RETRIES,
     DEFAULT_HYPERCUBE_MAX_ROWS,
     MAX_TABLES_AND_KEYS_DIM,
@@ -43,6 +44,11 @@ class QlikEngineAPI:
             self.ws_timeout_seconds = DEFAULT_WS_TIMEOUT
         # Single unified timeout — used for both connection and all Engine operations
         self.ws_operation_timeout = self.ws_timeout_seconds
+        ping_timeout_env = os.getenv("QLIK_WS_PING_TIMEOUT")
+        try:
+            self.ws_ping_timeout = float(ping_timeout_env) if ping_timeout_env else DEFAULT_WS_PING_TIMEOUT
+        except ValueError:
+            self.ws_ping_timeout = DEFAULT_WS_PING_TIMEOUT
         retries_env = os.getenv("QLIK_WS_RETRIES")
         try:
             self.ws_retries = int(retries_env) if retries_env else DEFAULT_WS_RETRIES
@@ -283,11 +289,19 @@ class QlikEngineAPI:
         Fix: use a short health-check timeout and require an actual pong
         frame back before declaring the connection alive. The full
         QLIK_WS_TIMEOUT is restored afterward for real requests.
+
+        The health-check timeout (QLIK_WS_PING_TIMEOUT, default 8s) is
+        deliberately more generous than "a ping/pong should be instant":
+        recv_data() blocks for the *first* frame that arrives, and on a
+        loaded proxy/VPN path a live connection's pong can legitimately
+        take a couple of seconds. Too tight a timeout doesn't corrupt
+        anything (ensure_app() just reconnects), but it does defeat the
+        point of caching by forcibly reconnecting healthy connections.
         """
         if not self.ws or not self.ws.connected:
             return False
         try:
-            self.ws.settimeout(3)
+            self.ws.settimeout(self.ws_ping_timeout)
             self.ws.ping()
             opcode, _ = self.ws.recv_data()
             return opcode == websocket.ABNF.OPCODE_PONG

--- a/qlik_sense_mcp_server/engine_api.py
+++ b/qlik_sense_mcp_server/engine_api.py
@@ -1,6 +1,7 @@
 """Qlik Sense Engine API client."""
 
 import json
+import uuid
 import websocket
 import ssl
 from typing import Dict, List, Any, Optional, Union
@@ -268,14 +269,35 @@ class QlikEngineAPI:
         self._cached_has_data = False
 
     def _is_connected(self) -> bool:
-        """Check if WebSocket connection is alive."""
+        """Check if WebSocket connection is alive.
+
+        Sending a ping alone is not sufficient: websocket-client's
+        `ping()` only writes the frame to the socket and returns, it does
+        not wait for or verify a pong. A silently-dropped connection
+        (proxy/firewall/idle timeout killed it without a TCP RST) still
+        accepts the write, so a send-only check reports "alive" on a dead
+        socket. The caller then trusts the cache, reuses it for a real
+        request, and blocks for the full QLIK_WS_TIMEOUT (~180s) waiting
+        for a reply that will never come.
+
+        Fix: use a short health-check timeout and require an actual pong
+        frame back before declaring the connection alive. The full
+        QLIK_WS_TIMEOUT is restored afterward for real requests.
+        """
         if not self.ws or not self.ws.connected:
             return False
         try:
+            self.ws.settimeout(3)
             self.ws.ping()
-            return True
+            opcode, _ = self.ws.recv_data()
+            return opcode == websocket.ABNF.OPCODE_PONG
         except Exception:
             return False
+        finally:
+            try:
+                self.ws.settimeout(self.ws_timeout_seconds)
+            except Exception:
+                pass
 
     def ensure_app(self, app_id: str, no_data: bool = False) -> int:
         """
@@ -1556,9 +1578,16 @@ class QlikEngineAPI:
                 "qInterColumnSortOrder": inter_column_sort_order,
             }
 
+            # qId MUST be unique per call, not just per shape (dims/measures
+            # count) — reusing a qId that was recently destroyed in the same
+            # Engine session can make CreateSessionObject return a stale
+            # cached calculation instead of evaluating the new qDef (caught
+            # live 10.08.2026: three consecutive calls with different set
+            # analysis, same "hypercube-1d-1m" qId, returned byte-identical
+            # results including for a deliberately non-matching filter).
             obj_def = {
                 "qInfo": {
-                    "qId": f"hypercube-{len(converted_dimensions)}d-{len(converted_measures)}m",
+                    "qId": f"hypercube-{len(converted_dimensions)}d-{len(converted_measures)}m-{uuid.uuid4().hex[:12]}",
                     "qType": "HyperCube",
                 },
                 "qHyperCubeDef": hypercube_def,
@@ -1878,8 +1907,12 @@ class QlikEngineAPI:
                 "qMode": "S",
             }
 
+            # Unique per call — see the comment on the same pattern in
+            # create_hypercube (a static qId can make Engine return a stale
+            # cached result instead of evaluating this call's own qDef).
+            obj_id = f"table-data-{table_name}-{uuid.uuid4().hex[:12]}"
             obj_def = {
-                "qInfo": {"qId": f"table-data-{table_name}", "qType": "HyperCube"},
+                "qInfo": {"qId": obj_id, "qType": "HyperCube"},
                 "qHyperCubeDef": hypercube_def,
             }
 
@@ -1901,7 +1934,7 @@ class QlikEngineAPI:
                 try:
                     self.send_request(
                         "DestroySessionObject",
-                        [f"table-data-{table_name}"],
+                        [obj_id],
                         handle=app_handle,
                     )
                 except Exception:
@@ -1946,7 +1979,7 @@ class QlikEngineAPI:
             try:
                 self.send_request(
                     "DestroySessionObject",
-                    [f"table-data-{table_name}"],
+                    [obj_id],
                     handle=app_handle,
                 )
             except Exception as cleanup_error:
@@ -1993,9 +2026,11 @@ class QlikEngineAPI:
     ) -> Dict[str, Any]:
         """Get field values with frequency information using ListObject."""
         try:
-            # Use correct structure
+            # Use correct structure. qId unique per call — see the comment
+            # on the same pattern in create_hypercube.
+            obj_id = f"field-values-{field_name}-{uuid.uuid4().hex[:12]}"
             list_def = {
-                "qInfo": {"qId": f"field-values-{field_name}", "qType": "ListObject"},
+                "qInfo": {"qId": obj_id, "qType": "ListObject"},
                 "qListObjectDef": {
                     "qStateName": "$",
                     "qLibraryId": "",
@@ -2038,7 +2073,7 @@ class QlikEngineAPI:
                 try:
                     self.send_request(
                         "DestroySessionObject",
-                        [f"field-values-{field_name}"],
+                        [obj_id],
                         handle=app_handle,
                     )
                 except Exception:
@@ -2085,7 +2120,7 @@ class QlikEngineAPI:
             try:
                 self.send_request(
                     "DestroySessionObject",
-                    [f"field-values-{field_name}"],
+                    [obj_id],
                     handle=app_handle,
                 )
             except Exception as cleanup_error:
@@ -2129,7 +2164,7 @@ class QlikEngineAPI:
         ListObject returns empty.
         """
         try:
-            obj_id = f"field-values-fb-{field_name}"
+            obj_id = f"field-values-fb-{field_name}-{uuid.uuid4().hex[:12]}"
             hypercube_def = {
                 "qDimensions": [
                     {
@@ -2233,8 +2268,9 @@ class QlikEngineAPI:
                 "qSuppressZero": False,
                 "qSuppressMissing": False,
             }
+            obj_id = f"field-range-{field_name}-{uuid.uuid4().hex[:12]}"
             obj_def = {
-                "qInfo": {"qId": f"field-range-{field_name}", "qType": "HyperCube"},
+                "qInfo": {"qId": obj_id, "qType": "HyperCube"},
                 "qHyperCubeDef": hypercube_def,
             }
             result = self.send_request(
@@ -2263,7 +2299,7 @@ class QlikEngineAPI:
                             }
             try:
                 self.send_request("DestroySessionObject",
-                                  [f"field-range-{field_name}"], handle=app_handle)
+                                  [obj_id], handle=app_handle)
             except Exception:
                 pass
             return stats
@@ -2328,8 +2364,9 @@ class QlikEngineAPI:
                 "qSuppressMissing": False,
             }
 
+            obj_id = f"field-stats-{field_name}-{uuid.uuid4().hex[:12]}"
             obj_def = {
-                "qInfo": {"qId": f"field-stats-{field_name}", "qType": "HyperCube"},
+                "qInfo": {"qId": obj_id, "qType": "HyperCube"},
                 "qHyperCubeDef": hypercube_def,
             }
 
@@ -2359,7 +2396,7 @@ class QlikEngineAPI:
                 try:
                     self.send_request(
                         "DestroySessionObject",
-                        [f"field-stats-{field_name}"],
+                        [obj_id],
                         handle=app_handle,
                     )
                 except Exception:
@@ -2431,7 +2468,7 @@ class QlikEngineAPI:
             try:
                 self.send_request(
                     "DestroySessionObject",
-                    [f"field-stats-{field_name}"],
+                    [obj_id],
                     handle=app_handle,
                 )
             except Exception as cleanup_error:
@@ -2721,9 +2758,10 @@ class QlikEngineAPI:
                             dim["qDef"]["qFieldDefs"] = [filter_expr]
                             break
 
+            obj_id = f"data-export-{table_name or 'custom'}-{uuid.uuid4().hex[:12]}"
             obj_def = {
                 "qInfo": {
-                    "qId": f"data-export-{table_name or 'custom'}",
+                    "qId": obj_id,
                     "qType": "HyperCube",
                 },
                 "qHyperCubeDef": hypercube_def,
@@ -2749,7 +2787,7 @@ class QlikEngineAPI:
                 try:
                     self.send_request(
                         "DestroySessionObject",
-                        [f"data-export-{table_name or 'custom'}"],
+                        [obj_id],
                         handle=app_handle,
                     )
                 except Exception:
@@ -2817,7 +2855,7 @@ class QlikEngineAPI:
             try:
                 self.send_request(
                     "DestroySessionObject",
-                    [f"data-export-{table_name or 'custom'}"],
+                    [obj_id],
                     handle=app_handle,
                 )
             except Exception as cleanup_error:

--- a/qlik_sense_mcp_server/engine_api.py
+++ b/qlik_sense_mcp_server/engine_api.py
@@ -556,6 +556,178 @@ class QlikEngineAPI:
 
         return response.get("result", {})
 
+    def send_requests_pipelined(
+        self, requests: List[Dict[str, Any]], timeout: float = None,
+        raise_on_error: bool = True,
+    ) -> List[Any]:
+        """
+        Send multiple independent JSON-RPC requests back-to-back, without
+        waiting for each response before sending the next, then collect all
+        responses.
+
+        Why this is safe: the Qlik Engine JSON API requires every request to
+        carry its own numeric `id` specifically so the client can match
+        responses to requests out of order — see "Let's Dissect the Qlik
+        Engine API - Part 1: RPC Basics" (Qlik Community). `send_request()`
+        sends one request and blocks for its matching response before
+        sending the next; for a batch of independent requests (e.g. N
+        sibling objects on a sheet, each needing its own GetObject/GetLayout)
+        that stacks N network round-trips even though nothing in the
+        protocol requires it.
+
+        What this does NOT claim: it does not change whether the Engine
+        computes/queues the N requests concurrently server-side — it only
+        removes client-side round-trip stacking. Whether that yields a real
+        wall-clock win depends on the workload (network RTT vs. per-request
+        server cost) and should be measured for the specific call site
+        before being relied on, not assumed.
+
+        Args:
+            requests: list of {"method": str, "params": list|dict, "handle": int}.
+            timeout: shared socket timeout applied to the whole batch
+                (default: `self.ws_timeout_seconds`, same as send_request).
+            raise_on_error: if True (default), raise a single Exception
+                aggregating every per-request Engine error, matching
+                send_request()'s raise-on-error behavior. If False, failed
+                requests are returned as `Exception` instances in place of
+                their result (mirrors
+                `asyncio.gather(..., return_exceptions=True)`), so the
+                caller can keep the successful items from a batch instead
+                of losing all of them to one bad request — used by
+                `_get_sheet_objects_detailed()` so one broken sheet object
+                doesn't drop every other object on the same sheet.
+
+        Returns:
+            List of `result` dicts (or Exception instances when
+            raise_on_error=False), in the same order as `requests`. Every
+            response for this batch is drained from the socket before
+            returning or raising, even on error, so the connection is never
+            left holding unread frames that a later call could mistake for
+            its own.
+        """
+        import socket as _socket
+        if not self.ws:
+            raise ConnectionError("Not connected to Engine API")
+        if not requests:
+            return []
+
+        effective_timeout = timeout if timeout is not None else self.ws_timeout_seconds
+        if timeout is not None:
+            self._set_socket_timeout(timeout)
+
+        # req_id -> index in `requests`, so responses (possibly out of
+        # order) land back in the caller's original order.
+        pending: Dict[int, int] = {}
+        outcomes: List[Any] = [None] * len(requests)
+
+        try:
+            for idx, req in enumerate(requests):
+                req_id = self._get_next_request_id()
+                pending[req_id] = idx
+                payload = {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "handle": req.get("handle", -1),
+                    "method": req["method"],
+                    "params": req.get("params") or [],
+                }
+                try:
+                    self.ws.send(json.dumps(payload))
+                except (_socket.timeout, TimeoutError) as e:
+                    self._kill_socket()
+                    raise TimeoutError(
+                        f"WebSocket send() timed out after {effective_timeout:.1f}s "
+                        f"mid-batch at item {idx} ('{req['method']}')"
+                    ) from e
+                except Exception as e:
+                    self._kill_socket()
+                    raise ConnectionError(
+                        f"WebSocket send() failed mid-batch at item {idx} "
+                        f"('{req['method']}'): {type(e).__name__}: {e}"
+                    ) from e
+
+            stray_frames = 0
+            stray_cap = max(100, 20 * len(requests))
+            while pending:
+                try:
+                    data = self.ws.recv()
+                except (_socket.timeout, TimeoutError) as e:
+                    self._kill_socket()
+                    raise TimeoutError(
+                        f"WebSocket recv() timed out after {effective_timeout:.1f}s "
+                        f"waiting for {len(pending)}/{len(requests)} outstanding "
+                        f"pipelined responses. Increase QLIK_WS_TIMEOUT if the "
+                        f"batch is legitimately heavy."
+                    ) from e
+                except Exception as e:
+                    self._kill_socket()
+                    raise ConnectionError(
+                        f"WebSocket recv() failed mid-batch "
+                        f"({len(pending)}/{len(requests)} still outstanding): "
+                        f"{type(e).__name__}: {e}"
+                    ) from e
+
+                try:
+                    frame = json.loads(data)
+                except Exception as parse_err:
+                    self._kill_socket()
+                    raise ConnectionError(
+                        f"Failed to parse WebSocket frame mid-batch "
+                        f"({len(pending)}/{len(requests)} still outstanding): "
+                        f"{parse_err}"
+                    ) from parse_err
+
+                frame_id = frame.get("id")
+                idx = pending.pop(frame_id, None)
+                if idx is None:
+                    # Notification, or a late reply to an earlier
+                    # timed-out request — same stray-frame handling as
+                    # send_request().
+                    if frame_id is None:
+                        logger.debug(
+                            "send_requests_pipelined: skipping notification: %s",
+                            frame.get("method", "<no-method>"),
+                        )
+                    else:
+                        logger.warning(
+                            "send_requests_pipelined: discarding stale frame "
+                            "with id=%s (not part of this batch)", frame_id,
+                        )
+                    stray_frames += 1
+                    if stray_frames > stray_cap:
+                        self._kill_socket()
+                        raise ConnectionError(
+                            f"send_requests_pipelined: received {stray_frames} "
+                            f"stray frames without matching all {len(requests)} "
+                            f"batch ids, killing connection"
+                        )
+                    continue
+
+                if "error" in frame:
+                    outcomes[idx] = Exception(
+                        f"Engine API error for method "
+                        f"'{requests[idx]['method']}' "
+                        f"(handle={requests[idx].get('handle', -1)}): {frame['error']}"
+                    )
+                else:
+                    outcomes[idx] = frame.get("result", {})
+        finally:
+            if timeout is not None and self.ws is not None:
+                try:
+                    self._set_socket_timeout(self.ws_timeout_seconds)
+                except Exception:
+                    pass
+
+        if raise_on_error:
+            errors = [o for o in outcomes if isinstance(o, Exception)]
+            if errors:
+                raise Exception(
+                    f"send_requests_pipelined: {len(errors)}/{len(requests)} "
+                    f"requests failed: {'; '.join(str(e) for e in errors)}"
+                )
+
+        return outcomes
+
     def get_doc_list(self) -> List[Dict[str, Any]]:
         """Get list of available documents."""
         try:
@@ -896,7 +1068,15 @@ class QlikEngineAPI:
             }
 
     def _get_sheet_objects_detailed(self, app_handle: int, sheet_id: str) -> List[Dict[str, Any]]:
-        """Get detailed information about objects on a sheet."""
+        """Get detailed information about objects on a sheet.
+
+        Fetches all child objects' handles and layouts in two pipelined
+        batches (see `send_requests_pipelined`) instead of one
+        GetObject+GetLayout round-trip per object — a sheet with N objects
+        used to cost 2N sequential round-trips, now costs 2 regardless of N.
+        Per-object failures are still isolated: one bad object is skipped,
+        the rest of the sheet is unaffected, same as before.
+        """
         try:
             sheet_result = self.send_request("GetObject", {"qId": sheet_id}, handle=app_handle)
             if "qReturn" not in sheet_result or "qHandle" not in sheet_result["qReturn"]:
@@ -910,21 +1090,51 @@ class QlikEngineAPI:
                 return []
 
             child_objects = sheet_layout["qLayout"]["qChildList"]["qItems"]
-            detailed_objects = []
+            child_meta = [
+                (co.get("qInfo", {}).get("qId", ""), co.get("qInfo", {}).get("qType", ""), co)
+                for co in child_objects
+            ]
+            child_meta = [(obj_id, obj_type, co) for obj_id, obj_type, co in child_meta if obj_id]
+            if not child_meta:
+                return []
 
-            for child_obj in child_objects:
-                obj_id = child_obj.get("qInfo", {}).get("qId", "")
-                obj_type = child_obj.get("qInfo", {}).get("qType", "")
-                if not obj_id:
+            # Wave 1: resolve every child object's handle in one pipelined
+            # round-trip instead of N sequential GetObject calls.
+            get_object_outcomes = self.send_requests_pipelined(
+                [{"method": "GetObject", "params": {"qId": obj_id}, "handle": app_handle}
+                 for obj_id, _obj_type, _co in child_meta],
+                raise_on_error=False,
+            )
+
+            obj_handles: List[Optional[int]] = []
+            for outcome in get_object_outcomes:
+                if (isinstance(outcome, Exception)
+                        or "qReturn" not in outcome or "qHandle" not in outcome["qReturn"]):
+                    obj_handles.append(None)
+                else:
+                    obj_handles.append(outcome["qReturn"]["qHandle"])
+
+            # Wave 2: fetch every resolved object's layout in one more
+            # pipelined round-trip instead of N sequential GetLayout calls.
+            layout_indices = [i for i, h in enumerate(obj_handles) if h is not None]
+            layout_outcomes = self.send_requests_pipelined(
+                [{"method": "GetLayout", "params": [], "handle": obj_handles[i]}
+                 for i in layout_indices],
+                raise_on_error=False,
+            ) if layout_indices else []
+            layout_by_index = dict(zip(layout_indices, layout_outcomes))
+
+            detailed_objects = []
+            for i, (obj_id, obj_type, child_obj) in enumerate(child_meta):
+                obj_layout = layout_by_index.get(i)
+                if obj_layout is None:
+                    continue  # GetObject failed for this child — same as the old `continue`
+                if isinstance(obj_layout, Exception):
+                    logger.warning(f"Error processing object {obj_id}: {obj_layout}")
+                    continue
+                if "qLayout" not in obj_layout:
                     continue
                 try:
-                    obj_result = self.send_request("GetObject", {"qId": obj_id}, handle=app_handle)
-                    if "qReturn" not in obj_result or "qHandle" not in obj_result["qReturn"]:
-                        continue
-                    obj_handle = obj_result["qReturn"]["qHandle"]
-                    obj_layout = self.send_request("GetLayout", [], handle=obj_handle)
-                    if "qLayout" not in obj_layout:
-                        continue
                     fields_used = self._extract_fields_from_object(obj_layout["qLayout"])
                     detailed_obj = {
                         "object_id": obj_id,

--- a/tests/test_pipelining.py
+++ b/tests/test_pipelining.py
@@ -1,0 +1,216 @@
+"""Tests for send_requests_pipelined() and its use in _get_sheet_objects_detailed().
+
+The whole point of pipelining is sending N requests before reading any
+response, then matching replies back to requests by `id` regardless of the
+order they arrive in — that's the behavior these tests exercise directly
+against a fake socket, not through send_request() (which is untouched).
+"""
+
+import json
+
+import pytest
+
+from qlik_sense_mcp_server.engine_api import QlikEngineAPI
+
+
+class _FakeSocket:
+    """Stand-in for `websocket.WebSocket`.
+
+    `send()` just records the frame and queues a scripted response for it
+    (looked up by method name). `recv()` pops from that queue — in
+    `reverse` mode it pops last-in-first-out, so responses come back in the
+    opposite order from how the requests were sent, proving id-matching
+    doesn't depend on send order.
+    """
+
+    def __init__(self, responses_by_method, reverse=False, error_methods=()):
+        self.sent_frames = []
+        self._responses_by_method = responses_by_method
+        self._reverse = reverse
+        self._error_methods = set(error_methods)
+        self._queue = []
+        self.sock = None  # so _set_socket_timeout's `self.ws.sock` check is a no-op
+
+    def send(self, data):
+        frame = json.loads(data)
+        self.sent_frames.append(frame)
+        if frame["method"] in self._error_methods:
+            response = {"jsonrpc": "2.0", "id": frame["id"],
+                        "error": {"message": f"{frame['method']} failed"}}
+        else:
+            result = self._responses_by_method.get(frame["method"], {})
+            response = {"jsonrpc": "2.0", "id": frame["id"], "result": result}
+        self._queue.append(response)
+
+    def recv(self):
+        return json.dumps(self._queue.pop() if self._reverse else self._queue.pop(0))
+
+    def settimeout(self, *_a, **_kw):
+        pass
+
+
+def _engine(sock):
+    eng = QlikEngineAPI.__new__(QlikEngineAPI)
+    eng.ws = sock
+    eng.request_id = 0
+    eng.ws_timeout_seconds = 30.0
+    return eng
+
+
+class TestSendRequestsPipelined:
+    def test_sends_all_before_reading_any_response(self):
+        """The defining property of pipelining: every request is on the
+        wire before we start waiting on responses."""
+        sock = _FakeSocket({"GetObject": {"qReturn": {"qHandle": 1}}})
+        eng = _engine(sock)
+        eng.send_requests_pipelined(
+            [{"method": "GetObject", "params": {"qId": f"obj{i}"}, "handle": 0}
+             for i in range(5)]
+        )
+        assert len(sock.sent_frames) == 5
+        assert [f["params"]["qId"] for f in sock.sent_frames] == [f"obj{i}" for i in range(5)]
+
+    def test_results_land_in_request_order_even_when_responses_are_reversed(self):
+        sock = _FakeSocket(
+            {"GetLayout": {"qLayout": {"title": "x"}}}, reverse=True,
+        )
+        eng = _engine(sock)
+        requests = [{"method": "GetLayout", "params": [], "handle": h} for h in (10, 20, 30)]
+        results = eng.send_requests_pipelined(requests)
+        # All three succeed and come back in *request* order, not arrival order.
+        assert results == [{"qLayout": {"title": "x"}}] * 3
+
+    def test_unique_ids_assigned_per_request(self):
+        sock = _FakeSocket({"GetObject": {}})
+        eng = _engine(sock)
+        eng.send_requests_pipelined(
+            [{"method": "GetObject", "params": {}, "handle": 0} for _ in range(4)]
+        )
+        ids = [f["id"] for f in sock.sent_frames]
+        assert len(set(ids)) == 4
+
+    def test_raise_on_error_true_aggregates_and_raises(self):
+        sock = _FakeSocket(
+            {"GetObject": {"qReturn": {"qHandle": 1}}},
+            error_methods={"GetLayout"},
+        )
+        eng = _engine(sock)
+        with pytest.raises(Exception, match="1/2 requests failed"):
+            eng.send_requests_pipelined([
+                {"method": "GetObject", "params": {}, "handle": 0},
+                {"method": "GetLayout", "params": [], "handle": 1},
+            ])
+
+    def test_raise_on_error_false_returns_exception_in_place(self):
+        sock = _FakeSocket(
+            {"GetObject": {"qReturn": {"qHandle": 1}}},
+            error_methods={"GetLayout"},
+        )
+        eng = _engine(sock)
+        results = eng.send_requests_pipelined(
+            [
+                {"method": "GetObject", "params": {}, "handle": 0},
+                {"method": "GetLayout", "params": [], "handle": 1},
+            ],
+            raise_on_error=False,
+        )
+        assert results[0] == {"qReturn": {"qHandle": 1}}
+        assert isinstance(results[1], Exception)
+
+    def test_empty_batch_is_a_noop(self):
+        eng = _engine(_FakeSocket({}))
+        assert eng.send_requests_pipelined([]) == []
+
+    def test_stray_notification_frames_are_skipped(self):
+        """A frame with no `id` (an Engine notification like OnConnected)
+        must not be mistaken for a batch response."""
+
+        class _SocketWithNotification(_FakeSocket):
+            def send(self, data):
+                if not self.sent_frames:
+                    # Inject a notification ahead of the real response.
+                    self._queue.append({"jsonrpc": "2.0", "method": "OnConnected", "params": {}})
+                super().send(data)
+
+        sock = _SocketWithNotification({"GetObject": {"qReturn": {"qHandle": 1}}})
+        eng = _engine(sock)
+        results = eng.send_requests_pipelined(
+            [{"method": "GetObject", "params": {}, "handle": 0}]
+        )
+        assert results == [{"qReturn": {"qHandle": 1}}]
+
+
+class TestSheetObjectsUsesPipelining:
+    """`_get_sheet_objects_detailed` should issue exactly 2 pipelined
+    batches for N child objects, not 2N sequential send_request calls."""
+
+    def _sheet_layout(self, child_ids):
+        return {
+            "qLayout": {
+                "qChildList": {
+                    "qItems": [
+                        {"qInfo": {"qId": cid, "qType": "chart"}} for cid in child_ids
+                    ]
+                }
+            }
+        }
+
+    def test_all_children_resolved_via_two_pipelined_waves(self, monkeypatch):
+        eng = QlikEngineAPI.__new__(QlikEngineAPI)
+        pipelined_calls = []
+
+        def fake_send_request(method, params=None, handle=-1, timeout=None):
+            if method == "GetObject":
+                return {"qReturn": {"qHandle": 999}}  # sheet handle itself
+            if method == "GetLayout":
+                return self._sheet_layout(["c1", "c2", "c3"])
+            raise AssertionError(f"unexpected send_request call: {method}")
+
+        def fake_pipelined(requests, timeout=None, raise_on_error=True):
+            pipelined_calls.append([r["method"] for r in requests])
+            if requests[0]["method"] == "GetObject":
+                return [{"qReturn": {"qHandle": 100 + i}} for i in range(len(requests))]
+            return [{"qLayout": {"title": f"obj{i}"}} for i in range(len(requests))]
+
+        eng.send_request = fake_send_request
+        eng.send_requests_pipelined = fake_pipelined
+        eng._extract_fields_from_object = lambda layout: []
+
+        result = eng._get_sheet_objects_detailed(app_handle=1, sheet_id="SH01")
+
+        assert len(result) == 3
+        assert [r["object_title"] for r in result] == ["obj0", "obj1", "obj2"]
+        # Exactly 2 batched calls total, regardless of how many children.
+        assert len(pipelined_calls) == 2
+        assert pipelined_calls[0] == ["GetObject"] * 3
+        assert pipelined_calls[1] == ["GetLayout"] * 3
+
+    def test_one_bad_child_does_not_drop_the_rest(self):
+        eng = QlikEngineAPI.__new__(QlikEngineAPI)
+
+        def fake_send_request(method, params=None, handle=-1, timeout=None):
+            if method == "GetObject":
+                return {"qReturn": {"qHandle": 999}}
+            if method == "GetLayout":
+                return self._sheet_layout(["good1", "bad", "good2"])
+            raise AssertionError(method)
+
+        def fake_pipelined(requests, timeout=None, raise_on_error=True):
+            if requests[0]["method"] == "GetObject":
+                # "bad" fails to resolve a handle at all.
+                return [
+                    {"qReturn": {"qHandle": 100}},
+                    Exception("GetObject failed"),
+                    {"qReturn": {"qHandle": 102}},
+                ]
+            # Only good1/good2 made it to the GetLayout wave.
+            assert len(requests) == 2
+            return [{"qLayout": {"title": "good1"}}, {"qLayout": {"title": "good2"}}]
+
+        eng.send_request = fake_send_request
+        eng.send_requests_pipelined = fake_pipelined
+        eng._extract_fields_from_object = lambda layout: []
+
+        result = eng._get_sheet_objects_detailed(app_handle=1, sheet_id="SH01")
+
+        assert [r["object_id"] for r in result] == ["good1", "good2"]


### PR DESCRIPTION
## Problem

The Qlik Engine JSON API requires every request to carry its own numeric id specifically so responses can be matched out of order (see Qlik Community, "Let's Dissect the Qlik Engine API - Part 1: RPC Basics"). `send_request()` sends one request and blocks for its matching response before sending the next; for a batch of independent requests that stacks N round-trips even though the protocol doesn't require it.

`_get_sheet_objects_detailed()` was previously issuing one `GetObject` + `GetLayout` round-trip per sheet object — 2N round-trips for N objects.

## Fix

Adds `send_requests_pipelined()` as a new, additive method (`send_request()` is untouched and still used everywhere else). Applies it to `_get_sheet_objects_detailed()`, which now sends two pipelined batches regardless of N. Per-object error isolation is preserved: one bad object is skipped, not the whole sheet.

## Testing

187/187 tests pass (178 previous + 9 new in `tests/test_pipelining.py`), run via `uv run pytest tests/ -q`.

**Not yet live-tested against a real Qlik Engine** — only unit-tested against a fake socket. Flagging this explicitly for review: worth measuring the real wall-clock effect on a loaded Engine before relying on it in production.
