### PR TITLE
Group e2e tests by app so the suite stops exhausting Qlik sessions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,28 @@ def pytest_configure(config):
     )
 
 
+# Which app each e2e module works against. Switching apps costs an Engine
+# session — Qlik will not open a second document on one socket, so the
+# client has to reconnect — and Qlik caps concurrent sessions per user.
+# Running the modules in app order turns a dozen switches into two.
+_APP_ORDER = {
+    "test_e2e_tools": 0,        # the small app (and its sheets)
+    "test_e2e_connection": 1,   # small app, plus one deliberate switch
+    "test_e2e_large_app": 2,    # the 10M-row app
+}
+
+
+def pytest_collection_modifyitems(items):
+    """Order e2e tests by the app they use; leave everything else alone."""
+    def key(item):
+        if "e2e" not in item.keywords:
+            return (0, 0)
+        module = item.module.__name__.rsplit(".", 1)[-1]
+        return (1, _APP_ORDER.get(module, 99))
+
+    items.sort(key=key)
+
+
 def _e2e_env():
     """Build the QLIK_* environment for a live run, or return None."""
     url = os.getenv("QLIK_E2E_URL")


### PR DESCRIPTION
Follow-up to #30, test-only.

**The problem.** Qlik will not open a second document on one Engine socket
(`OpenDoc` answers 1002 "App already open"), so every time the suite moved
between the small app, the sheet app and the 10M-row app, the client had to
reconnect — and each reconnect costs a session that outlives the socket.
With the modules interleaved that was a dozen switches, and the run hit the
per-user session cap halfway through: `OnMaxParallelSessionsExceeded`, a
wall of errors, and nothing wrong with the code under test.

**The fix.** `pytest_collection_modifyitems` orders e2e tests by the app
they use, leaving every other test where it was. Two switches instead of a
dozen.

Before: 26 failed, 6 passed, 20 errors, six minutes.
After: **52 passed in 7.75s**, no skips.

Also records two things learned the hard way, in the `qlik-live` skill:

- reading a load script needs `update` on the app, and the rule's resource
  filter must be `App*` — with `App_*` the rule does not apply to the App
  object itself, data reads fine, and the script silently comes back empty,
  which is indistinguishable from an app that has none;
- the licence on the stand is what gates who can run this at all.