### PR TITLE
Release v1.8.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.7.2
+current_version = 1.8.0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,79 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
-## [Unreleased]
+## [1.8.0] - 2026-08-11
+
+### Added
+
+- **`update_task_schedule` and `delete_task_schedule`** — a task can have
+  several triggers, and until now the only way to stop one through this
+  server was `update_task(enabled=False)`, which stops the task and every
+  other trigger with it. Both verified end to end against a live Qlik:
+  disable one trigger, retime it, give it a window, delete it.
+- `update_reload_task` refuses fields that must not travel in a PUT
+  (`id`, `createdDate`, the operational section) and reports a QRS 409 as
+  `error_category: conflict` — someone else changed the task between the
+  read and the write, which the caller answers by re-reading, not by
+  retrying blindly.
+- **`QlikEngineAPI.send_requests_pipelined()`** — sends a batch of
+  independent JSON-RPC requests back-to-back and matches responses by
+  `id`, which the Engine protocol supports precisely so replies can come
+  back out of order. `send_request()` is untouched. `raise_on_error=False`
+  returns per-item exceptions so one bad item does not lose the batch.
+  (from PR #29)
+- `_get_sheet_objects_detailed()` uses two pipelined batches instead of
+  one `GetObject`+`GetLayout` round-trip per object: 2 round-trips
+  instead of 2N. Measured on a live sheet with 16 objects: 0.135s to
+  0.028s, identical results. (from PR #29)
+- `QLIK_WS_IDLE_PROBE_AFTER` (default 30s), `QLIK_WS_PROBE_TIMEOUT`
+  (15s) and `QLIK_WS_GREETING_TIMEOUT` (15s) — liveness and handshake
+  budgets, separate from `QLIK_WS_TIMEOUT`, because a real query may
+  legitimately take minutes while a health check never should.
+  (adapted from PR #28)
+- **End-to-end test suite** (`tests/test_e2e_*.py`, marker `e2e`) that
+  runs the tools against a real Qlik and asserts on real values: ranking
+  actually ordered by the measure, pagination actually moving, NULL
+  groups actually dropped, the connection actually reused. Skipped
+  unless `QLIK_E2E_*` names a server. `tests/test_e2e_large_app.py`
+  additionally needs an app with 10M+ rows — none of the defects fixed
+  in this release could be reproduced by a fake socket.
+
+### Changed
+
+- **`get_app_variables` returns objects, always.** An empty group came
+  back as `""` instead of `{}`, so the field's type depended on whether it
+  had data. It also dropped script variables unless `created_in_script`
+  was passed explicitly, which left `variables_from_script` permanently
+  empty on the default call — half the reply was structurally dead. The
+  default now returns both sources, and the reply carries `count` and
+  `total_found`.
+- **`qSuppressMissing` is never set.** Measured on Qlik 31.62: it drops
+  exactly one row — the NULL-dimension group — and leaves rows with a NULL
+  *measure* untouched. That is what `qNullSuppression` per dimension
+  already does, under the caller's control, so the cube-wide flag only
+  ever meant an explicit "keep the NULL group" could be overridden.
+- **`engine_api.py` and `server.py` are split into packages.** The Engine
+  client became `engine/` — transport, hypercubes, fields, sheets and
+  app metadata as separate mixins assembled in `engine/api.py` — and the
+  tools became `tools/`, grouped by the API they talk to, with shared
+  state in `tools/context.py` and the response envelope in
+  `tools/helpers.py`. `from .engine_api import QlikEngineAPI` and
+  `from .server import get_apps` keep working; the largest module went
+  from 3394 lines to 875.
+
+### Removed
+
+- 43 methods that nothing called (~1180 lines): `get_table_data`,
+  `create_data_export`, `get_visualization_data`,
+  `get_detailed_app_metadata`, `get_sheets_with_objects`, bookmark and
+  selection helpers, and the rest of the unreachable surface of
+  `QlikEngineAPI` and `QlikRepositoryAPI`. Among them
+  `get_pivot_table_data`, which raised `NameError` on every call, and a
+  duplicate `get_field_description` shadowed by a later definition —
+  deleting the visible one would have silently reactivated the dead one.
 
 ### Fixed
+
 - **QRS paging is done by the server now.** `get_apps` fetched
   `app/full` — which ignores skip/take and is itself truncated at the
   QRS MaxRecordLimit (100 by default) — and then sliced the result
@@ -82,8 +152,6 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   `get_apps` turned a 500, a 403 or a refused connection into "nothing
   found". They now return `error_category: repository_error` with the
   original cause.
-
-### Fixed (from the review of this release)
 - `/count` replies are accepted in both shapes QRS uses — a bare integer
   and `{"value": N}`. Insisting on the object form would have failed
   every paged read on a server that answers with the number.
@@ -113,8 +181,6 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   branch of the Engine client and its helpers — two of which called
   methods that do not exist anywhere in the package — plus the unused
   ticket/proxy helpers and a no-op loop over `qChildList`.
-
-### Fixed (third review round)
 - **Wildcards are Qlik's, not Python's.** The case-sensitive filter went
   through `fnmatch`, which also reads `[...]` as a character class — so the
   pattern `Order[12]` matched the value `Order[1]`, a match Qlik would
@@ -138,8 +204,6 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   rather than in a `finally`.
 - **`_read_all`'s safety cap counts rows, not offsets**, so it no longer
   refuses the last page one row early.
-
-### Fixed (second review round)
 - **Case-sensitive field search kept its wildcards.** The previous fix
   reached for `Match()`, which respects case but does not understand `*`
   or `?` — verified on 31.62, `Match('C000001','C00000*')` is 0. Qlik has
@@ -173,42 +237,6 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   access; with an Analyzer licence Qlik returns an empty string and no
   error, which is indistinguishable from an app that has no script.
   `get_app_script` now attaches a `note` explaining the difference.
-
-### Added (closing the last open items)
-- **`update_task_schedule` and `delete_task_schedule`** — a task can have
-  several triggers, and until now the only way to stop one through this
-  server was `update_task(enabled=False)`, which stops the task and every
-  other trigger with it. Both verified end to end against a live Qlik:
-  disable one trigger, retime it, give it a window, delete it.
-- `update_reload_task` refuses fields that must not travel in a PUT
-  (`id`, `createdDate`, the operational section) and reports a QRS 409 as
-  `error_category: conflict` — someone else changed the task between the
-  read and the write, which the caller answers by re-reading, not by
-  retrying blindly.
-
-### Changed
-- **`get_app_variables` returns objects, always.** An empty group came
-  back as `""` instead of `{}`, so the field's type depended on whether it
-  had data. It also dropped script variables unless `created_in_script`
-  was passed explicitly, which left `variables_from_script` permanently
-  empty on the default call — half the reply was structurally dead. The
-  default now returns both sources, and the reply carries `count` and
-  `total_found`.
-- **`qSuppressMissing` is never set.** Measured on Qlik 31.62: it drops
-  exactly one row — the NULL-dimension group — and leaves rows with a NULL
-  *measure* untouched. That is what `qNullSuppression` per dimension
-  already does, under the caller's control, so the cube-wide flag only
-  ever meant an explicit "keep the NULL group" could be overridden.
-- **`engine_api.py` and `server.py` are split into packages.** The Engine
-  client became `engine/` — transport, hypercubes, fields, sheets and
-  app metadata as separate mixins assembled in `engine/api.py` — and the
-  tools became `tools/`, grouped by the API they talk to, with shared
-  state in `tools/context.py` and the response envelope in
-  `tools/helpers.py`. `from .engine_api import QlikEngineAPI` and
-  `from .server import get_apps` keep working; the largest module went
-  from 3394 lines to 875.
-
-### Fixed (earlier in this release)
 - **The cached WebSocket is no longer wedged by its own health check.**
   `_is_connected()` sent a WebSocket ping before reusing the connection.
   Qlik's Proxy Service does not relay ping/pong to the Engine: through a
@@ -264,40 +292,6 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   a stale cached calculation back instead of an evaluation of its own
   `qDef`. Every id now carries a `uuid4` suffix, and the matching
   `DestroySessionObject` uses the generated id. (from PR #27)
-
-### Added
-- **`QlikEngineAPI.send_requests_pipelined()`** — sends a batch of
-  independent JSON-RPC requests back-to-back and matches responses by
-  `id`, which the Engine protocol supports precisely so replies can come
-  back out of order. `send_request()` is untouched. `raise_on_error=False`
-  returns per-item exceptions so one bad item does not lose the batch.
-  (from PR #29)
-- `_get_sheet_objects_detailed()` uses two pipelined batches instead of
-  one `GetObject`+`GetLayout` round-trip per object: 2 round-trips
-  instead of 2N. Measured on a live sheet with 16 objects: 0.135s to
-  0.028s, identical results. (from PR #29)
-- `QLIK_WS_IDLE_PROBE_AFTER` (default 30s), `QLIK_WS_PROBE_TIMEOUT`
-  (15s) and `QLIK_WS_GREETING_TIMEOUT` (15s) — liveness and handshake
-  budgets, separate from `QLIK_WS_TIMEOUT`, because a real query may
-  legitimately take minutes while a health check never should.
-  (adapted from PR #28)
-- **End-to-end test suite** (`tests/test_e2e_*.py`, marker `e2e`) that
-  runs the tools against a real Qlik and asserts on real values: ranking
-  actually ordered by the measure, pagination actually moving, NULL
-  groups actually dropped, the connection actually reused. Skipped
-  unless `QLIK_E2E_*` names a server. `tests/test_e2e_large_app.py`
-  additionally needs an app with 10M+ rows — none of the defects fixed
-  in this release could be reproduced by a fake socket.
-
-### Removed
-- 43 methods that nothing called (~1180 lines): `get_table_data`,
-  `create_data_export`, `get_visualization_data`,
-  `get_detailed_app_metadata`, `get_sheets_with_objects`, bookmark and
-  selection helpers, and the rest of the unreachable surface of
-  `QlikEngineAPI` and `QlikRepositoryAPI`. Among them
-  `get_pivot_table_data`, which raised `NameError` on every call, and a
-  duplicate `get_field_description` shadowed by a later definition —
-  deleting the visible one would have silently reactivated the dead one.
 
 ## [1.7.2] - 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,19 @@ secrets). See [`docs/AUTH_JWT.md`](docs/AUTH_JWT.md) for the JWT setup.
 | [`docs/troubleshooting.md`](docs/troubleshooting.md) | Common errors, hypercube planning failures, verbose logging, configuration self-test |
 | [`CHANGELOG.md`](CHANGELOG.md) | Release notes |
 
-## Key facts about the v1.7.0 line
+## Key facts about the v1.8.0 line
+
+- **Paging is done by Qlik, not after it.** App and task listings read
+  `/{entity}/table` with `skip`/`take` and take the total from
+  `/{entity}/count`, so nothing past the QRS record limit goes missing
+  and `total_found` is the real total. Field search and field paging
+  likewise happen in Engine — verified on a field with 200,000 distinct
+  values, where the old local scan simply could not see a match.
+- **A failure is never an empty answer.** A QRS 500, a refused
+  connection or an Engine error used to arrive as `[]`, `""` or "no
+  schedule", which reads as a tidy, empty Qlik. Every such path now
+  returns an `error_category` and the original cause.
+
 
 - **Column meanings, not just column names.** Fields and tables commented
   in the load script (`COMMENT FIELD` / `COMMENT TABLE`) carry that text
@@ -100,12 +112,13 @@ secrets). See [`docs/AUTH_JWT.md`](docs/AUTH_JWT.md) for the JWT setup.
 - **Failures name the query that failed.** Every error reply, timeouts
   included, echoes `tool` and `request` with the exact arguments sent.
 - **Fewer useless tools in JWT mode.** Reload-task administration needs
-  QRS admin rights, so those 12 tools are registered only in
+  QRS admin rights, so those 14 tools are registered only in
   certificate mode: 26 tools with a certificate, 12 with a JWT.
-- **One Qlik session per server.** Qlik allows max 5 concurrent
-  sessions per user and can lock the account beyond that, so all tool
-  calls share a single cached Engine session — never fan them out in
-  parallel.
+- **One Qlik session per server.** Qlik's per-user limit (5 by default)
+  counts proxy sessions, and in JWT mode one is created by the session
+  bootstrap itself — before any WebSocket. The server therefore
+  bootstraps once and reuses that session for every call; restarting it
+  in a loop is what exhausts the quota, not the number of queries.
 - **JWT authentication via virtual proxy.** Set `QLIK_JWT_TOKEN`
   instead of certificate paths and the server will authenticate every
   Repository and Engine call as the analyst encoded in the token. No

--- a/docs/AUTH_JWT.md
+++ b/docs/AUTH_JWT.md
@@ -174,6 +174,17 @@ JWT is issued for one analyst, so all of that analyst's MCP activity
 shares the same 5-session budget. Exceeding it does not simply queue —
 Qlik treats it as abuse and can **lock the account**.
 
+What counts against that budget is the **proxy session**, not the
+WebSocket. Measured on 31.62: the `/qps/csrftoken` bootstrap creates a
+session on its own, before any socket exists — six bootstraps produce six
+sessions and the next WebSocket is refused with
+`OnMaxParallelSessionsExceeded`, even though nothing was connected.
+Sockets sharing one bootstrapped cookie are free: sixteen at once, and
+seven of them holding seven different apps open, all still counted as one
+session. So the cost is in how often the session is bootstrapped —
+restarting the server in a loop — and not in how many queries or apps go
+through it.
+
 Practical rules:
 
 - Run **one** MCP server process per token, and keep it running. The

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,20 +98,18 @@ line did. On a typical analysis session that issues 20 tool calls
 against the same app, the savings are significant: one WebSocket
 handshake plus one `OpenDoc` instead of twenty of each.
 
-#### Liveness without ping (since 1.7.3)
+#### Liveness without ping (since 1.8.0)
 
 Before reusing the cached socket, the client has to decide whether it is
 still alive. It must not do that with a WebSocket ping.
 
 Qlik's Proxy Service does not relay ping/pong to the Engine. Through a
 virtual proxy — that is, in every JWT deployment — the first request after
-a ping is never answered: the call blocks for the whole `QLIK_WS_TIMEOUT`,
-the socket is then force-closed, and the next call reconnects. Every forced
-reconnect costs an Engine session, Qlik allows 5 per user, and a session
-outlives the socket that created it, so a few minutes of ordinary use ends
-with `OnMaxParallelSessionsExceeded` and every tool failing. On a direct
-Engine socket (port 4747, certificate mode) the same ping is harmless,
-which is why the problem only ever appeared in JWT mode.
+a ping is never answered: the call blocks for the whole `QLIK_WS_TIMEOUT`
+(180s by default), the socket is then force-closed, and the next call
+reconnects — so in JWT mode every second tool call hung for minutes. On a
+direct Engine socket (port 4747, certificate mode) the same ping is
+harmless, which is why the problem only ever appeared in JWT mode.
 
 `_is_connected()` therefore:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -46,7 +46,7 @@ without them the e2e tests skip. `tests/test_e2e_large_app.py`
 additionally wants an app with 10M+ rows, because guard rails, ranking
 and paging only misbehave at a size a small app never reaches.
 
-This split is not a preference. Every defect fixed in the 1.7.3 line —
+This split is not a preference. Every defect fixed in the 1.8.0 line —
 a ping that wedged the socket through a proxy, a reused session-object
 id returning a stale calculation, paging that walked off the end of the
 data, a schedule QRS rejected outright — passed the offline tests and

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,7 +26,7 @@ uvx qlik-sense-mcp-server
 To pin a specific version:
 
 ```bash
-uvx qlik-sense-mcp-server@1.7.1
+uvx qlik-sense-mcp-server@1.8.0
 ```
 
 Do not pin below 1.6.1: earlier releases declare `mcp>=1.1.0` with no

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # Tools
 
-The server exposes up to **24** MCP tools, grouped into three areas:
+The server exposes up to **26** MCP tools, grouped into three areas:
 
 - **Repository API** — fast metadata via Qlik Repository (HTTP/QRS).
 - **Engine API** — data and load script via Qlik Engine (WebSocket).
@@ -8,12 +8,12 @@ The server exposes up to **24** MCP tools, grouped into three areas:
 
 **Availability depends on the authentication mode.** Task management
 calls QRS endpoints that require repository-admin rights, which a JWT
-analyst identity does not have, so those 12 tools are registered in
+analyst identity does not have, so those 14 tools are registered in
 certificate mode only:
 
 | Mode | Tools registered |
 |------|------------------|
-| certificate | 24 — everything below |
+| certificate | 26 — everything below |
 | JWT (virtual proxy) | 12 — Repository metadata + Engine only |
 
 Every tool returns its full parameter documentation via the standard MCP

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qlik-sense-mcp-server"
-version = "1.7.2"
+version = "1.8.0"
 description = "MCP Server for Qlik Sense Enterprise APIs"
 readme = "README.md"
 license = {text = "MIT"}

--- a/qlik_sense_mcp_server/__init__.py
+++ b/qlik_sense_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Qlik Sense MCP Server for Enterprise APIs."""
 
-__version__ = "1.7.2"
+__version__ = "1.8.0"


### PR DESCRIPTION
Cuts 1.8.0 from everything that accumulated under `[Unreleased]`, and folds the per-review-round subsections into the four Keep a Changelog headings.

**Why minor, not patch.** Several tool contracts changed:

- `get_app_field_statistics` reports `null_count` and `total_count` now means non-null + null, not `Count()`.
- `get_app_variables` always returns objects, and returns both sources by default.
- Tools that answered `[]` on a Repository failure now return `error_category: repository_error`.
- `create_task_schedule` refuses an unknown `repeat` and defaults `start_date` to the next midnight.

**Doc corrections found while preparing the release:**

- `docs/tools.md` claimed 24 tools and 12 certificate-only ones. The real numbers are 26 and 14 (3 QRS + 9 Engine + 14 task).
- The session accounting was wrong. Measured on 31.62: the `/qps/csrftoken` bootstrap creates a proxy session on its own — six bootstraps and no sockets at all are enough for the next WebSocket to be refused with `OnMaxParallelSessionsExceeded`. Sockets sharing one bootstrapped cookie are free: sixteen at once, seven of them holding seven different apps open, all still one session. A forced reconnect therefore does not cost a session; only a re-bootstrap does.

**Verified:** 358 offline tests, 51 e2e against a live Qlik 31.62 (1 skip is data-dependent).