### PR TITLE
Release v1.8.1 — follow the configured URL scheme, TLS verification off by default

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.8.0
+current_version = 1.8.1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)

--- a/.env.example
+++ b/.env.example
@@ -34,8 +34,10 @@ QLIK_ENGINE_PORT=4747
 # QLIK_HTTP_PORT=443
 
 # SSL and Security
-# Verify SSL certificates (true/false, default: true)
-QLIK_VERIFY_SSL=false
+# Verify TLS certificates (true/false, default: false).
+# Off by default because Qlik Sense Enterprise serves a self-signed
+# certificate; turn it on when Qlik presents one your machine trusts.
+# QLIK_VERIFY_SSL=true
 
 # Timeouts and Performance
 # HTTP request timeout in seconds (default: 10.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.8.1] - 2026-08-11
+
+### Changed
+
+- **The URL scheme decides the transport, including the WebSocket.**
+  `QLIK_SERVER_URL=http://host/jwt` now connects to Engine with `ws://`;
+  before, the scheme was honoured for every HTTP call but the WebSocket
+  was hard-coded to `wss://` on the grounds that TLS is mandatory. That
+  is not the client's decision to make: Qlik serves the virtual proxies
+  on 80 and 443 both, and a node whose proxy TLS has failed answers only
+  on 80 — the case that prompted this, where 443 stopped completing
+  handshakes while `http://host/jwt/qps/csrftoken` returned 204. Both
+  schemes are covered by tests, and the full e2e suite was run over
+  `http://` against a live Qlik. An `http://` URL is logged as a warning,
+  because the JWT and the session cookie then travel in clear text.
+- **TLS verification is off by default.** `QLIK_VERIFY_SSL` now defaults
+  to `false` and must be set to `true` to turn verification on. Qlik
+  Sense Enterprise serves its own self-signed certificate, so a correct
+  installation failed verification and every deployment was switching it
+  off anyway — a default that is wrong for the product it talks to only
+  teaches people to disable the setting without reading it.
+
+### Fixed
+
+- **Filter panes reported no fields.** Engine gives a hypercube a *list*
+  of `qDimensionInfo` and a list object exactly one; the extractor
+  iterated both as lists, so on a list object it walked the dict's keys
+  and raised `'str' object has no attribute 'get'`. A catch-all turned
+  that into a log warning and an empty field list, and filter panes are
+  precisely the objects that say which fields a sheet can be sliced by.
+- **`Sum(Sales)` now reports `Sales`.** Field extraction matched only
+  bracketed names, so any expression written without brackets — most of
+  them — contributed nothing to "which fields does this object use".
+  Names are now taken structurally: an identifier followed by `(` is a
+  function, string literals are values, everything else that is not a
+  keyword is a field. Calculated dimensions (`=Year(OrderDate)`) are read
+  the same way instead of being skipped.
+
 ## [1.8.0] - 2026-08-11
 
 ### Added

--- a/docs/AUTH_JWT.md
+++ b/docs/AUTH_JWT.md
@@ -146,6 +146,13 @@ Two variables — that is the whole configuration.
 
 - **`QLIK_SERVER_URL`** — the Qlik hostname with the virtual proxy prefix as
   URL path. If the admin used the default prefix `jwt`, the path is `/jwt`.
+  The scheme decides the transport for everything, WebSocket included:
+  `https://host/jwt` connects with `wss://`, `http://host/jwt` with `ws://`.
+  Prefer `https`. `http` is there because Qlik does serve the proxies on
+  port 80, and on a node whose proxy TLS is broken it is the only thing that
+  answers — but the token and the session cookie then travel in clear text,
+  so treat it as a stopgap on a trusted network and expect a warning in the
+  log saying so.
 - **`QLIK_JWT_TOKEN`** — the token string the admin gave you. Treat it like
   a password.
 
@@ -164,7 +171,7 @@ something non-standard.
 | `QLIK_JWT_USER_DIR_CLAIM` | Name of the payload claim holding the user directory | `userDirectory` |
 | `QLIK_JWT_SESSION_COOKIE` | Exact name of the VP session cookie | auto-detected from bootstrap response |
 | `QLIK_JWT_SESSION_TTL` | Seconds to cache the bootstrapped session before re-fetching. Lower this if the QMC Proxy `Session inactivity timeout` is below 30 min. | `1500` (25 min) |
-| `QLIK_VERIFY_SSL` | `false` disables TLS verification | `true` |
+| `QLIK_VERIFY_SSL` | `true` enables TLS verification | `false` |
 | `QLIK_CA_CERT_PATH` | Path to a corporate CA bundle | unset |
 
 ### 2.4 Session limit — run ONE session per token

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ the user identity travels in the JWT payload. See
 
 | Variable | Description |
 |----------|-------------|
-| `QLIK_SERVER_URL` | Qlik Sense server URL, including scheme. Example: `https://qlik.company.com`. In JWT mode include the virtual proxy prefix as URL path, e.g. `https://qlik.company.com/jwt`. |
+| `QLIK_SERVER_URL` | Qlik Sense server URL, including scheme. Example: `https://qlik.company.com`. In JWT mode include the virtual proxy prefix as URL path, e.g. `https://qlik.company.com/jwt`. The scheme is honoured everywhere, including the Engine WebSocket: `https` connects with `wss://`, `http` with `ws://`. Use `http` only on a trusted network — the token and session cookie are then unencrypted. |
 | `QLIK_USER_DIRECTORY` | User directory used for authentication (e.g. `COMPANY`). Cert mode only. |
 | `QLIK_USER_ID` | User ID used for authentication. Cert mode only. |
 
@@ -69,7 +69,7 @@ Defaults match the standard
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `QLIK_VERIFY_SSL` | `true` | Verify SSL certificates. Set to `false` for self-signed dev clusters. |
+| `QLIK_VERIFY_SSL` | `false` | Verify TLS certificates. Off by default: Qlik Sense Enterprise serves its own self-signed certificate, so a correct installation fails verification. Set to `true` once Qlik presents a certificate your machine trusts (and point `QLIK_CA_CERT_PATH` at the CA if it is a private one). |
 
 ## Timeouts and retries
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,8 +13,9 @@ hostname does not match. Steps:
    sign the Qlik Sense node certificate.
 2. Confirm the cert hasn't expired:
    `openssl x509 -in /path/to/root.pem -noout -dates`.
-3. As a temporary workaround for self-signed dev clusters, set
-   `QLIK_VERIFY_SSL=false`. Do not use this in production.
+3. Verification is off by default, so this error means it was turned
+   on deliberately (`QLIK_VERIFY_SSL=true`). Either point
+   `QLIK_CA_CERT_PATH` at the signing CA or drop the variable.
 
 ### `ConnectionError: Failed to connect to Engine API`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qlik-sense-mcp-server"
-version = "1.8.0"
+version = "1.8.1"
 description = "MCP Server for Qlik Sense Enterprise APIs"
 readme = "README.md"
 license = {text = "MIT"}

--- a/qlik_sense_mcp_server/__init__.py
+++ b/qlik_sense_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Qlik Sense MCP Server for Enterprise APIs."""
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"

--- a/qlik_sense_mcp_server/config.py
+++ b/qlik_sense_mcp_server/config.py
@@ -86,7 +86,11 @@ class QlikSenseConfig(BaseModel):
                                              "'https://qlik.company.com/jwt'.")
     user_directory: str = Field("", description="User directory for X-Qlik-User (certificate mode)")
     user_id: str = Field("", description="User ID for X-Qlik-User (certificate mode)")
-    verify_ssl: bool = Field(True, description="Verify SSL certificates")
+    verify_ssl: bool = Field(False, description="Verify TLS certificates. Off by default: a "
+                                                "Qlik Sense Enterprise deployment normally serves "
+                                                "its own self-signed certificate, so verification "
+                                                "fails on a correct installation. Set "
+                                                "QLIK_VERIFY_SSL=true to turn it on.")
     ca_cert_path: Optional[str] = Field(None, description="Path to CA certificate (optional, both modes)")
 
     # Certificate mode
@@ -184,6 +188,24 @@ class QlikSenseConfig(BaseModel):
                 f"{parsed_server.scheme!r}"
             )
 
+        if parsed_server.scheme == "http":
+            # Not refused: Qlik does serve the hub and the virtual proxies on
+            # plain HTTP, and on a deployment whose proxy certificate is
+            # broken it is the only thing that answers. But the JWT and the
+            # session cookie then travel in clear text, which the operator
+            # should be choosing deliberately rather than by a typo.
+            logger.warning(
+                "QLIK_SERVER_URL uses http:// — the JWT and the Qlik session "
+                "cookie will be sent unencrypted. Use https:// unless this is "
+                "a trusted network or the proxy's TLS is unavailable."
+            )
+        elif self.verify_ssl is False:
+            logger.info(
+                "TLS certificate verification is off (the default). "
+                "Set QLIK_VERIFY_SSL=true once Qlik serves a certificate "
+                "your machine trusts."
+            )
+
         if self.auth_mode == AUTH_MODE_JWT:
             if not self.virtual_proxy_prefix:
                 raise ValueError(
@@ -230,7 +252,7 @@ class QlikSenseConfig(BaseModel):
             proxy_port=int(os.getenv("QLIK_PROXY_PORT", str(DEFAULT_PROXY_PORT))),
             engine_port=int(os.getenv("QLIK_ENGINE_PORT", str(DEFAULT_ENGINE_PORT))),
             http_port=int(os.getenv("QLIK_HTTP_PORT")) if os.getenv("QLIK_HTTP_PORT") else None,
-            verify_ssl=os.getenv("QLIK_VERIFY_SSL", "true").lower() == "true",
+            verify_ssl=os.getenv("QLIK_VERIFY_SSL", "false").lower() == "true",
             jwt_token=os.getenv("QLIK_JWT_TOKEN") or None,
             jwt_user_id_claim=os.getenv("QLIK_JWT_USER_ID_CLAIM", DEFAULT_JWT_USER_ID_CLAIM),
             jwt_user_dir_claim=os.getenv("QLIK_JWT_USER_DIR_CLAIM", DEFAULT_JWT_USER_DIR_CLAIM),

--- a/qlik_sense_mcp_server/engine/connection.py
+++ b/qlik_sense_mcp_server/engine/connection.py
@@ -173,18 +173,23 @@ class EngineConnectionMixin:
         # Build endpoint list — per-app first if app_id is given.
         endpoints_all: List[str] = []
         if is_jwt:
-            # Via virtual proxy on 443 (or the configured non-standard port).
-            # No ws:// fallback — TLS is mandatory because the JWT was minted
-            # against a TLS-protected Host allow list in QMC.
+            # Via the virtual proxy, following the scheme the operator
+            # configured: `https://host/jwt` connects with wss://,
+            # `http://host/jwt` with ws://. Forcing wss:// regardless — which
+            # this used to do — makes the server unusable on a deployment
+            # whose proxy serves plain HTTP, and that is a real configuration:
+            # Qlik listens on 80 and 443 both, and 443 is the one that breaks
+            # when the proxy certificate is unhappy.
+            ws_scheme = "ws" if server_scheme == "http" else "wss"
             prefix = self.config.virtual_proxy_prefix
             if app_id:
                 enc = quote(app_id, safe="")
                 endpoints_all.append(
-                    f"wss://{server_netloc}/{prefix}/app/{enc}{jwt_csrf_qs}"
+                    f"{ws_scheme}://{server_netloc}/{prefix}/app/{enc}{jwt_csrf_qs}"
                 )
             endpoints_all.extend([
-                f"wss://{server_netloc}/{prefix}/app/engineData{jwt_csrf_qs}",
-                f"wss://{server_netloc}/{prefix}/app{jwt_csrf_qs}",
+                f"{ws_scheme}://{server_netloc}/{prefix}/app/engineData{jwt_csrf_qs}",
+                f"{ws_scheme}://{server_netloc}/{prefix}/app{jwt_csrf_qs}",
             ])
         else:
             if app_id:

--- a/qlik_sense_mcp_server/engine/sheets.py
+++ b/qlik_sense_mcp_server/engine/sheets.py
@@ -7,6 +7,19 @@ from ..exceptions import QlikEngineError
 
 logger = logging.getLogger(__name__)
 
+# Words that appear where a field name could, but never name a field:
+# operators, set-analysis syntax, constants, and the aggregation modifiers
+# that are written without parentheses.
+_EXPRESSION_KEYWORDS = frozenset("""
+    and or not xor like precedes follows
+    if then else elseif end
+    total distinct all aggr
+    null true false
+    as in when
+    intervalmatch resident inline autogenerate
+    e pi
+""".split())
+
 
 class EngineSheetsMixin:
     def get_script(self, app_handle: int) -> str:
@@ -143,30 +156,48 @@ class EngineSheetsMixin:
             raise
 
     def _extract_fields_from_object(self, obj_layout: Dict[str, Any]) -> List[str]:
-        """Extract field names used in an object layout."""
-        fields = set()
-        try:
-            if "qHyperCube" in obj_layout:
-                hypercube = obj_layout["qHyperCube"]
-                for dim_info in hypercube.get("qDimensionInfo", []):
-                    field_defs = dim_info.get("qGroupFieldDefs", [])
-                    for field_def in field_defs:
-                        field_name = self._extract_field_name_from_expression(field_def)
-                        if field_name:
-                            fields.add(field_name)
-                for measure_info in hypercube.get("qMeasureInfo", []):
-                    measure_def = measure_info.get("qDef", "")
-                    extracted_fields = self._extract_fields_from_expression(measure_def)
-                    fields.update(extracted_fields)
+        """Extract field names used in an object layout.
 
-            if "qListObject" in obj_layout:
-                list_obj = obj_layout["qListObject"]
-                for dim_info in list_obj.get("qDimensionInfo", []):
-                    field_defs = dim_info.get("qGroupFieldDefs", [])
-                    for field_def in field_defs:
-                        field_name = self._extract_field_name_from_expression(field_def)
-                        if field_name:
-                            fields.add(field_name)
+        A hypercube carries a *list* of qDimensionInfo, a list object exactly
+        one — Engine's own shapes, not a quirk of some charts. Iterating the
+        list object's as a list walked the dict's keys and raised
+        `'str' object has no attribute 'get'`, which the catch-all below
+        turned into a warning and an empty field list. Filter panes are the
+        objects built on list objects, so every filter on every sheet came
+        back as "uses no fields".
+        """
+        fields = set()
+
+        def add_dimension(dim_info: Any) -> None:
+            if not isinstance(dim_info, dict):
+                return
+            for field_def in dim_info.get("qGroupFieldDefs", []):
+                field_name = self._extract_field_name_from_expression(field_def)
+                if field_name:
+                    fields.add(field_name)
+                else:
+                    # A calculated dimension, e.g. "=Year(OrderDate)": the
+                    # simple form finds nothing, but the fields inside it are
+                    # exactly what the caller asked about.
+                    fields.update(self._extract_fields_from_expression(field_def))
+
+        try:
+            hypercube = obj_layout.get("qHyperCube")
+            if isinstance(hypercube, dict):
+                for dim_info in hypercube.get("qDimensionInfo", []):
+                    add_dimension(dim_info)
+                for measure_info in hypercube.get("qMeasureInfo", []):
+                    if isinstance(measure_info, dict):
+                        fields.update(
+                            self._extract_fields_from_expression(measure_info.get("qDef", ""))
+                        )
+
+            list_obj = obj_layout.get("qListObject")
+            if isinstance(list_obj, dict):
+                dim_info = list_obj.get("qDimensionInfo")
+                # Tolerate a list too: some object types nest several.
+                for entry in (dim_info if isinstance(dim_info, list) else [dim_info]):
+                    add_dimension(entry)
 
         except Exception as e:
             logger.warning(f"Error extracting fields from object: {e}")
@@ -185,12 +216,36 @@ class EngineSheetsMixin:
         return None
 
     def _extract_fields_from_expression(self, expression: str) -> List[str]:
-        """Extract field names from a complex expression."""
+        """Extract field names from a Qlik expression.
+
+        Bracketed names are unambiguous. Bare ones are not, so the rule is
+        structural: an identifier followed by `(` is a function call, and
+        everything else that is not a keyword is taken as a field. Matching
+        only `[...]` — as this did — meant `Sum(Sales)` reported no fields at
+        all, and most real measures are written without brackets.
+
+        This is a lexical guess, not a parser: an unusual function name would
+        be reported as a field. That is the tolerable direction of error for
+        "which fields does this object touch".
+        """
         import re
-        fields = []
+
         if not expression:
-            return fields
-        bracket_fields = re.findall(r'\[([^\]]+)\]', expression)
-        fields.extend(bracket_fields)
-        return list(set(fields))
+            return []
+
+        fields = set(re.findall(r"\[([^\]]+)\]", expression))
+
+        # Drop string literals first — 'Sales' inside a set expression is a
+        # value, not a field.
+        without_literals = re.sub(r"'[^']*'", " ", expression)
+        # And bracketed names, already collected above.
+        without_literals = re.sub(r"\[[^\]]*\]", " ", without_literals)
+
+        for match in re.finditer(r"\b([A-Za-z_][A-Za-z0-9_.]*)\s*(\()?", without_literals):
+            name, is_call = match.group(1), match.group(2)
+            if is_call or name.lower() in _EXPRESSION_KEYWORDS:
+                continue
+            fields.add(name)
+
+        return sorted(fields)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -85,7 +85,25 @@ class TestQlikSenseConfig:
         assert config.client_key_path is None
         assert config.ca_cert_path is None
         assert config.http_port is None
-        assert config.verify_ssl is True
+        # Off by default: Qlik Sense Enterprise serves its own self-signed
+        # certificate, so verification fails on a correct installation and
+        # every operator was turning it off anyway.
+        assert config.verify_ssl is False
+
+    def test_verification_is_opt_in_from_the_environment(self):
+        with patch.dict(os.environ, {
+            "QLIK_SERVER_URL": "https://qlik.example.com",
+            "QLIK_USER_DIRECTORY": "DOMAIN",
+            "QLIK_USER_ID": "admin",
+        }, clear=True):
+            assert QlikSenseConfig.from_env().verify_ssl is False
+        with patch.dict(os.environ, {
+            "QLIK_SERVER_URL": "https://qlik.example.com",
+            "QLIK_USER_DIRECTORY": "DOMAIN",
+            "QLIK_USER_ID": "admin",
+            "QLIK_VERIFY_SSL": "true",
+        }, clear=True):
+            assert QlikSenseConfig.from_env().verify_ssl is True
 
     def test_custom_ports(self):
         config = QlikSenseConfig(

--- a/tests/test_sheet_object_fields.py
+++ b/tests/test_sheet_object_fields.py
@@ -1,0 +1,111 @@
+"""Which fields a sheet object uses.
+
+Engine describes a chart with a *list* of `qDimensionInfo` and a filter pane
+with exactly one — a list object holds a single dimension by definition. The
+extractor treated both as lists, so on a filter pane it iterated the dict and
+walked its keys: `'str' object has no attribute 'get'`, caught by a
+catch-all, logged as a warning, and the object reported no fields at all.
+
+Filter panes are the objects that say which fields a sheet lets you slice
+by, so the answer to "what does this sheet work with" was missing exactly
+the part a reader would look for first.
+"""
+
+import logging
+
+import pytest
+
+from qlik_sense_mcp_server.engine_api import QlikEngineAPI
+
+
+@pytest.fixture
+def engine():
+    return QlikEngineAPI.__new__(QlikEngineAPI)
+
+
+def _list_object(field_name):
+    """A filter pane as Engine actually returns it: one dimension, not a list."""
+    return {
+        "qListObject": {
+            "qSize": {"qcx": 1, "qcy": 12},
+            "qDimensionInfo": {
+                "qFallbackTitle": field_name,
+                "qGroupFieldDefs": [field_name],
+            },
+        }
+    }
+
+
+class TestListObjects:
+    def test_filter_pane_field_is_found(self, engine):
+        assert engine._extract_fields_from_object(_list_object("Region")) == ["Region"]
+
+    def test_no_warning_is_logged(self, engine, caplog):
+        """The defect was visible only as a log line; assert on it directly."""
+        with caplog.at_level(logging.WARNING):
+            engine._extract_fields_from_object(_list_object("Region"))
+        assert not [r for r in caplog.records if "extracting fields" in r.message]
+
+    def test_a_list_of_dimensions_is_tolerated(self, engine):
+        layout = {"qListObject": {"qDimensionInfo": [
+            {"qGroupFieldDefs": ["Region"]},
+            {"qGroupFieldDefs": ["Country"]},
+        ]}}
+        assert sorted(engine._extract_fields_from_object(layout)) == ["Country", "Region"]
+
+    def test_missing_dimension_info_is_not_an_error(self, engine):
+        assert engine._extract_fields_from_object({"qListObject": {}}) == []
+
+
+class TestHypercubeObjects:
+    def test_dimensions_and_measure_fields(self, engine):
+        layout = {"qHyperCube": {
+            "qDimensionInfo": [{"qGroupFieldDefs": ["Region"]}],
+            "qMeasureInfo": [{"qDef": "Sum(Sales)"}],
+        }}
+        assert sorted(engine._extract_fields_from_object(layout)) == ["Region", "Sales"]
+
+    def test_an_object_with_both_shapes(self, engine):
+        """Some objects carry a hypercube and a list object at once."""
+        layout = {
+            "qHyperCube": {"qDimensionInfo": [{"qGroupFieldDefs": ["Year"]}],
+                           "qMeasureInfo": []},
+            "qListObject": {"qDimensionInfo": {"qGroupFieldDefs": ["Region"]}},
+        }
+        assert sorted(engine._extract_fields_from_object(layout)) == ["Region", "Year"]
+
+    def test_a_text_object_uses_no_fields(self, engine):
+        assert engine._extract_fields_from_object({"qInfo": {"qType": "text-image"}}) == []
+
+    def test_junk_in_place_of_a_hypercube_is_survived(self, engine):
+        assert engine._extract_fields_from_object({"qHyperCube": "unexpected"}) == []
+
+    def test_a_calculated_dimension_reports_the_fields_inside_it(self, engine):
+        layout = {"qHyperCube": {
+            "qDimensionInfo": [{"qGroupFieldDefs": ["=Year(OrderDate)"]}],
+            "qMeasureInfo": [],
+        }}
+        assert engine._extract_fields_from_object(layout) == ["OrderDate"]
+
+
+class TestExpressions:
+    """Bare field names matter: most measures are written without brackets."""
+
+    @pytest.mark.parametrize("expression, expected", [
+        ("Sum(Sales)", ["Sales"]),
+        ("Sum([Net Sales])", ["Net Sales"]),
+        ("Sum(Sales) / Count(distinct OrderID)", ["OrderID", "Sales"]),
+        ("Sum({<Year={2025}>} Sales)", ["Sales", "Year"]),
+        ("If(Region='North', Sum(Sales), 0)", ["Region", "Sales"]),
+        ("Sum(Aggr(Sum(Sales), Customer))", ["Customer", "Sales"]),
+        ("Count(total <Region> CustomerID)", ["CustomerID", "Region"]),
+        ("1 + 2", []),
+        ("", []),
+    ])
+    def test_expression(self, engine, expression, expected):
+        assert engine._extract_fields_from_expression(expression) == expected
+
+    def test_a_string_literal_is_not_a_field(self, engine):
+        """'North' is a value being compared against, not a column."""
+        assert "North" not in engine._extract_fields_from_expression(
+            "Sum(If(Region='North', Sales))")

--- a/tests/test_ws_scheme.py
+++ b/tests/test_ws_scheme.py
@@ -1,0 +1,107 @@
+"""The WebSocket follows the scheme the operator configured.
+
+`QLIK_SERVER_URL=http://host/jwt` has to connect with `ws://`. The client
+used to hard-code `wss://` on the grounds that TLS is mandatory, which is
+not a decision it gets to make: Qlik serves the virtual proxies on 80 and
+443 both, and when the proxy's TLS is broken — a state this very server hit
+on a live stand, where 443 stopped completing handshakes while 80 answered
+`204` — plain HTTP is the only thing that works.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from qlik_sense_mcp_server.config import QlikSenseConfig
+from qlik_sense_mcp_server.engine_api import QlikEngineAPI
+
+
+class _Session:
+    """A JwtSession that is already bootstrapped."""
+
+    csrf_token = "tok-123"
+
+    def ensure_standalone(self):
+        pass
+
+    def cookie_header(self):
+        return "X-Qlik-Session-jwt=abc"
+
+
+def _client(server_url):
+    config = QlikSenseConfig(server_url=server_url, jwt_token="jwt-payload")
+    return QlikEngineAPI(config, jwt_session=_Session())
+
+
+def _connect_and_capture(client, **kwargs):
+    """Run connect() against a stubbed websocket, return the URLs it tried."""
+    tried = []
+
+    def create_connection(url, **cc_kwargs):
+        tried.append((url, cc_kwargs))
+        ws = MagicMock()
+        ws.recv.return_value = '{"jsonrpc":"2.0","method":"OnConnected","params":{}}'
+        return ws
+
+    with patch("websocket.create_connection", side_effect=create_connection):
+        client.connect(**kwargs)
+    return tried
+
+
+class TestScheme:
+    def test_http_url_connects_over_ws(self):
+        tried = _connect_and_capture(_client("http://qlik.example.com/jwt"))
+        assert tried[0][0].startswith("ws://"), tried[0][0]
+
+    def test_https_url_connects_over_wss(self):
+        tried = _connect_and_capture(_client("https://qlik.example.com/jwt"))
+        assert tried[0][0].startswith("wss://"), tried[0][0]
+
+    def test_plain_ws_carries_no_ssl_context(self):
+        """websocket-client rejects sslopt on a non-TLS connection."""
+        tried = _connect_and_capture(_client("http://qlik.example.com/jwt"))
+        assert "sslopt" not in tried[0][1]
+
+    def test_wss_carries_the_ssl_context(self):
+        tried = _connect_and_capture(_client("https://qlik.example.com/jwt"))
+        assert "sslopt" in tried[0][1]
+
+    @pytest.mark.parametrize("url, expected", [
+        ("http://qlik.example.com/jwt", "ws://qlik.example.com/jwt/app/"),
+        ("http://qlik.example.com:8080/jwt", "ws://qlik.example.com:8080/jwt/app/"),
+        ("https://qlik.example.com:8443/jwt", "wss://qlik.example.com:8443/jwt/app/"),
+    ])
+    def test_port_is_preserved(self, url, expected):
+        tried = _connect_and_capture(_client(url), app_id="app-1")
+        assert tried[0][0].startswith(expected), tried[0][0]
+
+    def test_every_fallback_endpoint_uses_the_same_scheme(self):
+        """A wss:// fallback after a ws:// first try would fail confusingly."""
+        client = _client("http://qlik.example.com/jwt")
+        client.ws_retries = 5
+        tried = _connect_and_capture(client, app_id="app-1")
+        # Only the first succeeds here, so force the failure path instead.
+        with patch("websocket.create_connection", side_effect=OSError("refused")):
+            with pytest.raises(Exception):
+                client.connect(app_id="app-1")
+        assert all(url.startswith("ws://") for url, _ in tried)
+
+
+class TestHeaders:
+    def test_origin_matches_the_configured_scheme(self):
+        """Qlik compares Origin against the VP host allow list."""
+        tried = _connect_and_capture(_client("http://qlik.example.com/jwt"))
+        headers = tried[0][1]["header"]
+        assert "Origin: http://qlik.example.com" in headers
+
+    def test_csrf_token_travels_in_the_url_and_the_header(self):
+        tried = _connect_and_capture(_client("http://qlik.example.com/jwt"))
+        url, kwargs = tried[0]
+        assert "qlik-csrf-token=tok-123" in url
+        assert "qlik-csrf-token: tok-123" in kwargs["header"]
+
+    def test_no_bearer_on_the_upgrade(self):
+        """CSWSH protection rejects an Authorization header on the upgrade."""
+        tried = _connect_and_capture(_client("https://qlik.example.com/jwt"))
+        assert not any(h.lower().startswith("authorization")
+                       for h in tried[0][1]["header"])


### PR DESCRIPTION
Three changes, all found by using the server against a stand whose proxy TLS had failed.

**The URL scheme decides the transport, WebSocket included.** `QLIK_SERVER_URL=http://host/jwt` now connects with `ws://`. It used to be hard-coded to `wss://` on the grounds that TLS is mandatory — not the client's call to make. Qlik serves the virtual proxies on 80 and 443 both, and on the stand this was found on, 443 stopped completing handshakes (even from localhost) while `http://host/jwt/qps/csrftoken` answered 204. The whole e2e suite was then run over `http://`. An `http://` URL is logged as a warning: the token and session cookie travel in clear text.

**`QLIK_VERIFY_SSL` defaults to `false`.** Qlik Sense Enterprise serves its own self-signed certificate, so verification failed on a correct installation and every deployment was switching it off. Set it to `true` to turn verification back on.

**Filter panes reported no fields.** Engine gives a hypercube a list of `qDimensionInfo` and a list object exactly one; the extractor iterated both as lists, so on a list object it walked the dict's keys and raised `'str' object has no attribute 'get'`. A catch-all turned that into a log warning and an empty field list — and filter panes are precisely the objects that say which fields a sheet can be sliced by. Field extraction also matched only bracketed names, so `Sum(Sales)` contributed nothing.

Verified: 389 offline tests, 51 e2e against a live Qlik 31.62 over `http://`.