### PR TITLE
Release v1.9.0 — refuse queries Qlik would answer with a wrong number

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.8.1
+current_version = 1.9.0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,82 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.9.0] - 2026-08-11
+
+### Added
+
+- **A query that names something that does not exist is now refused.**
+  Qlik evaluates an unknown name as an expression worth 0 rather than
+  reporting an error, so a typo came back as data: measured on 31.62, a
+  hypercube grouped by `no_such_field` returned a single row holding
+  49,989,556,885.52 — the grand total over all ten regions, and
+  indistinguishable from a real answer. Dimension fields are now checked
+  against the data model before the cube is built (one pipelined
+  `GetFieldDescription` batch, ~0.01s), and an unknown one comes back as
+  `error_category: field_not_found` with `did_you_mean` suggestions.
+- **Measures that quietly evaluate to nothing are called out.** Every
+  reply carries `warnings`. A measure whose every value is `0` or `'-'`
+  is flagged — that is what Qlik returns for a set-analysis filter
+  matching no value (`region_name={'Moscow'}` where the data says
+  `Moskva`), a misspelled field inside an aggregation, or an expression
+  it could not evaluate. SQL written into a measure (`AS`, `SELECT`,
+  `GROUP BY`, `FROM`, `WHERE`) is named as such, and names inside a
+  measure that the model does not have are reported without blocking the
+  query, since they are found lexically.
+- **Objects report the expressions behind them.**
+  `get_app_sheet_objects` returns `fields_used`, `measures` and
+  `dimensions` — all three were computed and then dropped, so answering
+  "what does this sheet work with" meant one call per object, and the
+  expressions were not reachable at all. `get_app_object` gained the
+  same three: its docstring promised "dimension/measure definitions and
+  expressions" while returning a layout that does not contain them.
+
+### Fixed
+
+- **A calculated dimension skipped the check.** `=Year(no_such_field)`
+  was passed through unexamined because an expression is not a field
+  name — leaving open the exact hole the check exists to close. The
+  names inside it are now read too, as a warning rather than a refusal.
+- **An empty result is explained.** `suppress_zero=True` turns a full
+  table of zeros into no rows at all, and the per-column check needs
+  rows to look at, so the warning went quiet precisely when the answer
+  was emptiest.
+- **The SQL check no longer fires on a legal field name.** It scanned
+  the raw expression, so a field called `[Cost as planned]` read as an
+  SQL alias. Bracketed names and string literals are masked first — and
+  masked rather than removed, so `AS "total"`, the alias form a model
+  writes most often, is still caught.
+- **Measure expressions were read from the wrong place.** The code
+  looked for `qMeasureInfo.qDef` in the object layout, and Engine does
+  not put it there — verified against a live sheet, where every measure
+  arrived with `qFallbackTitle`, formatting and statistics but no
+  definition at all. The expression lives in the properties
+  (`qHyperCubeDef.qMeasures[].qDef.qDef`), which are now fetched in the
+  same pipelined pass. Objects also report their `measures` and
+  `dimensions` with expressions and labels.
+- **Charts built from the library reported no fields.** A master measure
+  or dimension stores only `qLibraryId`; those are now resolved through
+  `GetMeasure`/`GetDimension` — so precisely the charts a modeller took
+  the trouble to standardise stop being the ones that answer "no fields".
+- **Filter panes report the fields they filter on.** A filter pane is a
+  container: the fields live in its listbox children, one level down, and
+  reading only the top level reported every filter pane as using nothing.
+- **Non-Latin field names are found.** The identifier pattern was
+  `[A-Za-z_]`, so a chart grouped by `Год` and `Месяц` — the actual
+  dimensions on the stand — contributed no fields. Numeric literals no
+  longer count either: `Count(distinct id) / 1e3` used to report `1e3`
+  as a field.
+- **A double-quoted search is a value, not a field.**
+  `Sum({<Country={"New Zealand"}>} Sales)` reported `New` and `Zealand`
+  as fields of the data model. Both quote styles and `$(variable)`
+  expansions are now removed before names are read.
+- **Certificate mode follows the URL scheme too.** It listed both
+  `wss://` endpoints before the `ws://` ones, and with the default retry
+  budget of 2 the plain-WebSocket entries were unreachable — so
+  `QLIK_SERVER_URL=http://host` could not connect at all. The requested
+  scheme is now tried first and exhausted before the other. (1.8.1 fixed
+  this for JWT mode only.)
+
 ## [1.8.1] - 2026-08-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -68,8 +68,19 @@ secrets). See [`docs/AUTH_JWT.md`](docs/AUTH_JWT.md) for the JWT setup.
 | [`docs/troubleshooting.md`](docs/troubleshooting.md) | Common errors, hypercube planning failures, verbose logging, configuration self-test |
 | [`CHANGELOG.md`](CHANGELOG.md) | Release notes |
 
-## Key facts about the v1.8.0 line
+## Key facts about the v1.9.0 line
 
+- **A wrong query is refused, not answered.** Qlik evaluates an unknown
+  field name as an expression worth 0, so a hypercube grouped by a typo
+  came back as a single row holding the grand total — a plausible number
+  with nothing to mark it as wrong. Dimension fields are checked against
+  the data model first (about 10ms), and measures that come back entirely
+  zero, contain SQL, or mention names the model does not have are
+  reported in `warnings`.
+- **Objects say which fields they use.** `get_app_sheet_objects` returns
+  `fields_used`, including fields reached through master measures and the
+  ones inside a filter pane's listboxes — so "what does this sheet work
+  with" is one call.
 - **Paging is done by Qlik, not after it.** App and task listings read
   `/{entity}/table` with `skip`/`take` and take the total from
   `/{entity}/count`, so nothing past the QRS record limit goes missing
@@ -80,8 +91,6 @@ secrets). See [`docs/AUTH_JWT.md`](docs/AUTH_JWT.md) for the JWT setup.
   connection or an Engine error used to arrive as `[]`, `""` or "no
   schedule", which reads as a tidy, empty Qlik. Every such path now
   returns an `error_category` and the original cause.
-
-
 - **Column meanings, not just column names.** Fields and tables commented
   in the load script (`COMMENT FIELD` / `COMMENT TABLE`) carry that text
   into `get_app_details` as `comment`, and into `get_app_field` as

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -37,8 +37,8 @@ categories. The lists below are a quick map only.
 | `get_app_script` | Full load script (`SET`/`LET`, `LOAD ... FROM ...`). Read this to understand how calendar fields and named variables are built. |
 | `get_app_variables` | User variables split by source (script vs UI), with wildcard search and pagination. |
 | `get_app_sheets` | List of sheets in the app, with title and description. |
-| `get_app_sheet_objects` | List of objects on a specific sheet, with `object_id`, `object_type`, `object_description`. |
-| `get_app_object` | Full layout of one specific object via `GetObject` + `GetLayout`. Reverse-engineers an existing chart. |
+| `get_app_sheet_objects` | List of objects on a specific sheet, with `object_id`, `object_type`, `object_description`, `fields_used`, `measures` and `dimensions` — the expressions behind each object, with master items resolved to their library definitions and filter panes reporting the fields of their listboxes. |
+| `get_app_object` | Full layout of one object, plus `measures`, `dimensions` and `fields_used`. Read the expressions from `measures`: Engine does not put them in the layout, where `qMeasureInfo` carries only the fallback title, formatting and statistics. Master items are resolved to their library definitions. |
 | `get_app_field` | Distinct values of one field with pagination and wildcard search, both applied by Engine over the whole field rather than over a prefetched prefix. Falls back to a single-dimension hypercube if the underlying `ListObject` returns nothing. Adds `field_comment` when the load script commented that field. |
 | `engine_get_field_range` | Lightning-fast bounds for one field: count distinct, min, max. Implemented as a measures-only hypercube — runs in seconds on any table size. Prefer this over `get_app_field_statistics`. |
 | `get_app_field_statistics` | Field statistics via a measures-only hypercube. Defaults to **light** mode (count distinct, non-null count, null count, total count, min, max, null %, completeness — the null share comes from `NullCount()`, not from subtracting one non-null count from another). Pass `full=true` to also compute avg / sum / median / mode / stdev — slow on big fact tables and meaningless for date/text fields. |
@@ -107,6 +107,24 @@ On failure, tools return:
 so a failed call always tells you *which* query failed, not just that
 something timed out.
 
+### Warnings
+
+A successful `engine_create_hypercube` reply carries a `warnings` list.
+It is empty on a clean query and names the things Qlik answers instead
+of refusing:
+
+- a measure whose every value came back `0` or `'-'` — the signature of
+  a set-analysis filter matching no value, a misspelled field inside the
+  aggregation, or an expression Engine could not evaluate;
+- SQL written into a measure (`AS`, `SELECT`, `GROUP BY`, `FROM`,
+  `WHERE`), which returns a full table of `'-'`;
+- a name inside a measure that the data model does not have (found
+  lexically, so a variable or an unusual function may appear here —
+  it warns rather than blocks).
+
+Treat a warning as "check this before quoting the number", not as a
+failure: the rows are real, their meaning may not be.
+
 The categories you can see from `engine_create_hypercube`:
 
 - `invalid_sort` — `sort_by` matched no column, or `sort_order` was not
@@ -117,6 +135,11 @@ The categories you can see from `engine_create_hypercube`:
   reduce `limit`. The hint contains an exact suggested value.
 - `socket_timeout` — Engine is genuinely computing something slow. Add
   more set-analysis filters, reduce `max_rows`, or switch to top-N.
+- `field_not_found` — a dimension names a field the data model does
+  not have. Qlik would not refuse it: an unknown name is evaluated as
+  an expression, the cube collapses to one row carrying the grand
+  total, and that reads as a real answer. The reply lists
+  `unknown_fields` and `did_you_mean`.
 - `engine_api_error` — invalid expression / unknown field. The full
   Engine error is in `error`.
 - `connection_error` — WebSocket connection problem.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qlik-sense-mcp-server"
-version = "1.8.1"
+version = "1.9.0"
 description = "MCP Server for Qlik Sense Enterprise APIs"
 readme = "README.md"
 license = {text = "MIT"}

--- a/qlik_sense_mcp_server/__init__.py
+++ b/qlik_sense_mcp_server/__init__.py
@@ -1,3 +1,3 @@
 """Qlik Sense MCP Server for Enterprise APIs."""
 
-__version__ = "1.8.1"
+__version__ = "1.9.0"

--- a/qlik_sense_mcp_server/engine/connection.py
+++ b/qlik_sense_mcp_server/engine/connection.py
@@ -192,17 +192,23 @@ class EngineConnectionMixin:
                 f"{ws_scheme}://{server_netloc}/{prefix}/app{jwt_csrf_qs}",
             ])
         else:
-            if app_id:
-                enc = quote(app_id, safe="")
-                endpoints_all.append(
-                    f"wss://{server_host}:{self.config.engine_port}/app/{enc}"
-                )
-            endpoints_all.extend([
-                f"wss://{server_host}:{self.config.engine_port}/app/engineData",
-                f"wss://{server_host}:{self.config.engine_port}/app",
-                f"ws://{server_host}:{self.config.engine_port}/app/engineData",
-                f"ws://{server_host}:{self.config.engine_port}/app",
-            ])
+            # Certificate mode talks to the Engine port directly, but the
+            # scheme is still the operator's to choose: `http://host` means
+            # ws://. The opposite scheme stays in the list as a fallback,
+            # after the requested one — before this, both wss:// entries came
+            # first and the default retry budget of 2 meant ws:// was never
+            # reached at all.
+            primary, fallback = (("ws", "wss") if server_scheme == "http"
+                                 else ("wss", "ws"))
+            port = self.config.engine_port
+            for scheme in (primary, fallback):
+                if app_id:
+                    enc = quote(app_id, safe="")
+                    endpoints_all.append(f"{scheme}://{server_host}:{port}/app/{enc}")
+                endpoints_all.extend([
+                    f"{scheme}://{server_host}:{port}/app/engineData",
+                    f"{scheme}://{server_host}:{port}/app",
+                ])
         # ws_retries controls how many fallback endpoints to try; always at
         # least 1, and if app_id is given we add +1 to include the per-app URL
         # without starving the fallback list.

--- a/qlik_sense_mcp_server/engine/hypercube.py
+++ b/qlik_sense_mcp_server/engine/hypercube.py
@@ -10,11 +10,32 @@ from ..config import (
     DEFAULT_HYPERCUBE_MAX_ROWS,
 )
 from typing import Dict, List, Any, Optional
+import difflib
 import logging
+import re
 import time
 import uuid
 
 logger = logging.getLogger(__name__)
+
+# Qlik evaluates an unknown name as an expression worth 0 rather than
+# refusing it, so a typo comes back as data. These patterns catch the shapes
+# that produce a confident, wrong answer.
+_DOLLAR_EXPANSION = re.compile(r"\$\([^)]*\)")
+# Field names and string values, which must not be scanned for SQL keywords:
+# `[Cost as planned]` is a perfectly good field name.
+_QUOTED_OR_BRACKETED = re.compile(r"\[[^\]]*\]|'[^']*'|\"[^\"]*\"")
+_SQL_ISMS = (
+    # The alias may be bare, bracketed or quoted — `AS "total"` is the form
+    # a model writes most often, and it used to pass unnoticed.
+    (re.compile(r"\bas\s+[\w\[\"']", re.I | re.UNICODE),
+     "`AS <alias>` is SQL; in Qlik a measure is named with the `label` argument"),
+    (re.compile(r"\bselect\b", re.I), "`SELECT` is SQL; a measure is just the aggregation"),
+    (re.compile(r"\bgroup\s+by\b", re.I), "`GROUP BY` is SQL; grouping is what `dimensions` does"),
+    (re.compile(r"\bfrom\s+[A-Za-z_\[]", re.I), "`FROM` is SQL; a hypercube has no table clause"),
+    (re.compile(r"\bwhere\b", re.I), "`WHERE` is SQL; filter with set analysis, "
+                                     "e.g. Sum({<Year={2026}>} Amount)"),
+)
 
 
 class EngineHypercubeMixin:
@@ -35,6 +56,197 @@ class EngineHypercubeMixin:
         "asc": 1, "ascending": 1, "up": 1, "low": 1,
         "lowest": 1, "bottom": 1, "1": 1,
     }
+
+    def _known_field_names(self, app_handle: int) -> List[str]:
+        """Every field in the data model, for suggesting a near miss.
+
+        Only called on the error path — it walks the model, which the
+        happy path has no reason to pay for.
+        """
+        try:
+            model = self.get_fields(app_handle)
+        except Exception as exc:
+            logger.debug("Could not list fields for a suggestion: %s", exc)
+            return []
+        # get_fields names the key `field_name`; the tool layer renames it to
+        # `name` on the way out. Accept both so this keeps working whichever
+        # one it is handed. Deduplicated: a join key appears once per table it
+        # belongs to, and suggesting it three times helps nobody.
+        names = [
+            f.get("field_name") or f.get("name") or ""
+            for f in (model.get("fields") or [])
+            if f.get("field_name") or f.get("name")
+        ]
+        return list(dict.fromkeys(names))
+
+    def _fields_exist(self, app_handle: int, names: List[str]) -> Dict[str, bool]:
+        """Ask Engine which of these names the data model actually has.
+
+        `GetFieldDescription` is the cheap answer — no hypercube, no data
+        page — and the batch goes out in one pipelined round-trip.
+        """
+        if not names:
+            return {}
+        try:
+            outcomes = self.send_requests_pipelined(
+                [{"method": "GetFieldDescription", "params": [name], "handle": app_handle}
+                 for name in names],
+                raise_on_error=False,
+            )
+        except Exception as exc:
+            # The check is a guard, not the query. If it cannot run, let the
+            # query through — refusing it would turn a diagnostic into an
+            # outage, and an unchecked name still gets the empty-measure
+            # warning after the fact.
+            logger.debug("Field existence check unavailable, skipping: %s", exc)
+            return {}
+        exists = {}
+        for name, outcome in zip(names, outcomes):
+            if isinstance(outcome, Exception):
+                # Engine answers "Invalid parameters" for an unknown field.
+                exists[name] = False
+                continue
+            info = (outcome or {}).get("qReturn") or {}
+            exists[name] = bool(info.get("qName"))
+        return exists
+
+    def _validate_cube_inputs(
+        self, app_handle: int,
+        dimensions: List[Dict[str, Any]],
+        measures: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Catch the mistakes Qlik answers with a number instead of an error.
+
+        A dimension naming a field that does not exist is fatal: Qlik
+        evaluates the name as an expression, which collapses the cube to a
+        single row carrying the grand total — a result that looks exactly
+        like a legitimate answer. Measured on 31.62: a cube on
+        `no_such_field` returned one row worth 49,989,556,885.52, the total
+        over all ten regions.
+
+        Measure expressions get warnings rather than errors, because the
+        field names inside them are found lexically and a false positive
+        must not block a working query.
+        """
+        unknown_dimension_fields: List[str] = []
+        warnings: List[str] = []
+
+        dimension_fields = []
+        calculated_dimension_fields: List[str] = []
+        for dim in dimensions:
+            field = (dim.get("field") or "").strip()
+            if not field:
+                continue
+            if field.startswith("="):
+                # A calculated dimension is an expression, so it is not a
+                # field name — but the names *inside* it are, and skipping
+                # them outright let `=Year(no_such_field)` back through the
+                # exact hole this check exists to close. Lexical, so a
+                # warning rather than a refusal.
+                calculated_dimension_fields.extend(
+                    self._extract_fields_from_expression(
+                        _DOLLAR_EXPANSION.sub(" ", field.lstrip("=")))
+                )
+                continue
+            dimension_fields.append(field.strip("[]"))
+
+        measure_fields: List[str] = []
+        for measure in measures:
+            expression = measure.get("expression") or ""
+            # Strip bracketed names and string literals before looking for
+            # SQL: a field legitimately called [Cost as planned] contains
+            # the word "as", and warning about it sends the caller to
+            # rewrite a query that works.
+            # Replaced by a placeholder rather than removed, so that
+            # `AS "total"` — the alias form a model writes most often —
+            # still reads as `AS X` and is caught.
+            for_sql_check = _QUOTED_OR_BRACKETED.sub("X", expression)
+            for pattern, explanation in _SQL_ISMS:
+                if pattern.search(for_sql_check):
+                    warnings.append(
+                        f"Measure {expression!r} looks like SQL: {explanation}. "
+                        f"Qlik does not refuse it — every row comes back as "
+                        f"'-' instead."
+                    )
+                    break
+            # Variable expansion is resolved by Qlik, not by us; the names
+            # inside it are not field names.
+            measure_fields.extend(
+                self._extract_fields_from_expression(_DOLLAR_EXPANSION.sub(" ", expression))
+            )
+        measure_fields.extend(calculated_dimension_fields)
+
+        to_check = list(dict.fromkeys(dimension_fields + measure_fields))
+        exists = self._fields_exist(app_handle, to_check)
+
+        unknown_dimension_fields = [f for f in dimension_fields if not exists.get(f, True)]
+        unknown_measure_fields = [
+            f for f in measure_fields
+            if not exists.get(f, True) and f not in unknown_dimension_fields
+        ]
+
+        if unknown_dimension_fields:
+            known = self._known_field_names(app_handle)
+            # Matching case-insensitively and answering with the real name:
+            # field names are case-sensitive in Qlik, so the wrong case is
+            # the most common way to miss — and `REGION_NAME` is exactly the
+            # miss a case-sensitive comparison fails to explain.
+            folded = {name.casefold(): name for name in known}
+            suggestions = {}
+            for name in unknown_dimension_fields:
+                matches = difflib.get_close_matches(
+                    name.casefold(), list(folded), n=3, cutoff=0.6)
+                if matches:
+                    suggestions[name] = [folded[m] for m in matches]
+            return {
+                "error": (
+                    "Unknown field(s) in dimensions: "
+                    + ", ".join(repr(f) for f in unknown_dimension_fields)
+                ),
+                "error_category": "field_not_found",
+                "failed_step": "validate",
+                "unknown_fields": unknown_dimension_fields,
+                "did_you_mean": {k: v for k, v in suggestions.items() if v},
+                "hint": (
+                    "Qlik does not refuse an unknown dimension — it evaluates "
+                    "the name as an expression, and the cube collapses to one "
+                    "row holding the grand total, which reads as a real "
+                    "answer. Check the name with get_app_details (field names "
+                    "are case-sensitive)."
+                ),
+            }
+
+        if unknown_measure_fields:
+            warnings.append(
+                "Measure expressions mention name(s) the data model does not "
+                "have: " + ", ".join(repr(f) for f in unknown_measure_fields)
+                + ". Qlik scores an unknown name as 0, so the measure will "
+                  "read as zero rather than fail. (If these are variables or "
+                  "function names, ignore this.)"
+            )
+
+        return {"warnings": warnings}
+
+    @staticmethod
+    def _measure_columns_are_empty(rows: List[List[Any]], n_dims: int,
+                                   column_names: List[str]) -> List[str]:
+        """Name the measures that came back entirely 0 or '-'.
+
+        The signature of a mistake Qlik will not report: a set-analysis
+        filter on a value that does not exist, a misspelled field inside an
+        aggregation, SQL syntax. All of them return a full, well-formed
+        result whose numbers are meaningless.
+        """
+        if not rows:
+            return []
+        empty = []
+        for col in range(n_dims, len(column_names)):
+            values = [row[col] for row in rows if col < len(row)]
+            if not values:
+                continue
+            if all(v in (0, 0.0, "-", "", None) for v in values):
+                empty.append(column_names[col])
+        return empty
 
     @staticmethod
     def _normalize_sort_order(sort_order: Any) -> Optional[int]:
@@ -531,6 +743,18 @@ class EngineHypercubeMixin:
                 "qHyperCubeDef": hypercube_def,
             }
 
+            # Before spending a session object on it: does the query name
+            # things that exist? Qlik answers a typo with a number, so this
+            # is the difference between an error and a wrong answer.
+            step = "validate"
+            t_step = time.monotonic()
+            validation = self._validate_cube_inputs(
+                app_handle, converted_dimensions, converted_measures)
+            timings["validate_seconds"] = round(time.monotonic() - t_step, 3)
+            if validation.get("error"):
+                return validation
+            input_warnings: List[str] = validation.get("warnings", [])
+
             step = "CreateSessionObject"
             logger.info(
                 "create_hypercube: %s (dims=%d, measures=%d, max_rows=%d, op_timeout=%.1fs)",
@@ -642,9 +866,38 @@ class EngineHypercubeMixin:
 
             timings["total_seconds"] = round(time.monotonic() - t0, 3)
 
+            rows = self._matrix_to_rows(initial_pages, column_names)
+            warnings = list(input_warnings)
+            if not rows and converted_measures:
+                # No rows at all is the *strongest* version of the same
+                # signal, and `suppress_zero` turns a table of zeros into
+                # exactly this — so the check below, which needs rows to
+                # look at, would go quiet precisely when the result is
+                # emptiest.
+                warnings.append(
+                    "The query returned no rows. With suppress_zero=True that "
+                    "is what a measure evaluating to 0 everywhere looks like; "
+                    "otherwise the dimensions have no values under the current "
+                    "filters. Re-run without suppress_zero to tell the two "
+                    "apart."
+                    if suppress_zero else
+                    "The query returned no rows: no dimension value satisfied "
+                    "the query. Check the field names and any set-analysis "
+                    "filter values with get_app_field."
+                )
+            for empty_column in self._measure_columns_are_empty(rows, n_dims, column_names):
+                warnings.append(
+                    f"Every value of {empty_column!r} came back 0 or '-'. That "
+                    f"is what Qlik returns for a set-analysis filter matching "
+                    f"no value, a misspelled field inside the aggregation, or "
+                    f"an expression it could not evaluate — it does not report "
+                    f"any of them as an error. Check the filter values with "
+                    f"get_app_field before trusting this as a real zero."
+                )
+
             response: Dict[str, Any] = {
                 "columns": column_names,
-                "rows": self._matrix_to_rows(initial_pages, column_names),
+                "rows": rows,
                 "total_rows": total_rows_on_server,
                 "returned_rows": rows_fetched,
                 "total_columns": total_cols,
@@ -666,6 +919,7 @@ class EngineHypercubeMixin:
                 ],
                 "hard_max_rows": HARD_MAX_ROWS,
                 "truncation_warning": truncation_warning,
+                "warnings": warnings,
                 "timings": timings,
                 "dimensions": converted_dimensions,
                 "measures": converted_measures,

--- a/qlik_sense_mcp_server/engine/sheets.py
+++ b/qlik_sense_mcp_server/engine/sheets.py
@@ -122,6 +122,32 @@ class EngineSheetsMixin:
             ) if layout_indices else []
             layout_by_index = dict(zip(layout_indices, layout_outcomes))
 
+            # Wave 3: the layout does NOT carry measure expressions. Verified
+            # on 31.62 against a live sheet: `qMeasureInfo` has
+            # qFallbackTitle, formatting and statistics, but no `qDef` —
+            # reading the expression from the layout found nothing on every
+            # real object. The definition lives in the properties, under
+            # qHyperCubeDef.qMeasures[].qDef.qDef.
+            property_outcomes = self.send_requests_pipelined(
+                [{"method": "GetProperties", "params": [], "handle": obj_handles[i]}
+                 for i in layout_indices],
+                raise_on_error=False,
+            ) if layout_indices else []
+            properties_by_index = dict(zip(layout_indices, property_outcomes))
+
+            expressions_by_index = {
+                i: self._object_expressions(properties_by_index.get(i))
+                for i in layout_indices
+            }
+            # A filter pane holds no fields itself — it is a container whose
+            # listbox children each carry one. Reading only the top level
+            # reported every filter pane on every sheet as using no fields,
+            # which is the opposite of what a filter pane is for.
+            nested_fields = self._nested_object_fields(app_handle, layout_by_index)
+            # Wave 4: master items carry a library id instead of a definition,
+            # so resolve those in one more batch.
+            self._resolve_library_items(app_handle, expressions_by_index)
+
             detailed_objects = []
             for i, (obj_id, obj_type, child_obj) in enumerate(child_meta):
                 obj_layout = layout_by_index.get(i)
@@ -133,13 +159,29 @@ class EngineSheetsMixin:
                 if "qLayout" not in obj_layout:
                     continue
                 try:
-                    fields_used = self._extract_fields_from_object(obj_layout["qLayout"])
+                    expressions = expressions_by_index.get(i) or {"measures": [], "dimensions": []}
+                    fields_used = set(self._extract_fields_from_object(obj_layout["qLayout"]))
+                    fields_used.update(nested_fields.get(i, []))
+                    for measure in expressions["measures"]:
+                        fields_used.update(
+                            self._extract_fields_from_expression(measure.get("expression", "")))
+                    for dimension in expressions["dimensions"]:
+                        for field_def in dimension.get("fields", []):
+                            name = self._extract_field_name_from_expression(field_def)
+                            if name:
+                                fields_used.add(name)
+                            else:
+                                fields_used.update(
+                                    self._extract_fields_from_expression(field_def))
+                    fields_used = sorted(fields_used)
                     detailed_obj = {
                         "object_id": obj_id,
                         "object_type": obj_type,
                         "object_title": obj_layout["qLayout"].get("title", ""),
                         "object_subtitle": obj_layout["qLayout"].get("subtitle", ""),
                         "fields_used": fields_used,
+                        "measures": expressions["measures"],
+                        "dimensions": expressions["dimensions"],
                         "basic_info": child_obj,
                         "detailed_layout": obj_layout["qLayout"]
                     }
@@ -154,6 +196,184 @@ class EngineSheetsMixin:
         except Exception as e:
             logger.error("_get_sheet_objects_detailed error: %s", e)
             raise
+
+    def _nested_object_fields(self, app_handle: int,
+                              layout_by_index: Dict[int, Any]) -> Dict[int, List[str]]:
+        """Fields used by the children of container objects.
+
+        One level deep: that covers the filter pane, which is the container
+        that matters and the only one commonly nested on a sheet. A
+        container inside a container would need recursion, and buying that
+        with two more round-trips per level is not worth it until something
+        actually needs it.
+        """
+        wanted = []  # (parent_index, child_id)
+        for index, layout in layout_by_index.items():
+            if isinstance(layout, Exception) or not isinstance(layout, dict):
+                continue
+            children = ((layout.get("qLayout") or {}).get("qChildList") or {}).get("qItems") or []
+            for child in children:
+                child_id = ((child or {}).get("qInfo") or {}).get("qId")
+                if child_id:
+                    wanted.append((index, child_id))
+        if not wanted:
+            return {}
+
+        try:
+            handle_outcomes = self.send_requests_pipelined(
+                [{"method": "GetObject", "params": {"qId": child_id}, "handle": app_handle}
+                 for _parent, child_id in wanted],
+                raise_on_error=False,
+            )
+        except Exception as exc:
+            logger.debug("Could not resolve nested objects: %s", exc)
+            return {}
+
+        handles = []
+        for outcome in handle_outcomes:
+            if isinstance(outcome, Exception):
+                handles.append(None)
+                continue
+            handles.append(((outcome or {}).get("qReturn") or {}).get("qHandle"))
+
+        positions = [i for i, handle in enumerate(handles) if handle is not None]
+        try:
+            layouts = self.send_requests_pipelined(
+                [{"method": "GetLayout", "params": [], "handle": handles[i]}
+                 for i in positions],
+                raise_on_error=False,
+            ) if positions else []
+        except Exception as exc:
+            logger.debug("Could not read nested object layouts: %s", exc)
+            return {}
+
+        by_parent: Dict[int, List[str]] = {}
+        for position, layout in zip(positions, layouts):
+            if isinstance(layout, Exception) or not isinstance(layout, dict):
+                continue
+            parent_index = wanted[position][0]
+            fields = self._extract_fields_from_object(layout.get("qLayout") or {})
+            if fields:
+                by_parent.setdefault(parent_index, []).extend(fields)
+        return by_parent
+
+    @staticmethod
+    def _object_expressions(properties: Any) -> Dict[str, List[Dict[str, Any]]]:
+        """Measure and dimension definitions from an object's properties.
+
+        Returns them in the shape a reader wants — expression plus label —
+        rather than Qlik's doubly-nested `qDef.qDef`. A master item has no
+        expression here, only `qLibraryId`; those are filled in afterwards
+        by `_resolve_library_items`.
+        """
+        empty: Dict[str, List[Dict[str, Any]]] = {"measures": [], "dimensions": []}
+        if isinstance(properties, Exception) or not isinstance(properties, dict):
+            return empty
+        cube = ((properties.get("qProp") or {}).get("qHyperCubeDef")) or {}
+        if not isinstance(cube, dict):
+            return empty
+
+        measures = []
+        for measure in cube.get("qMeasures", []) or []:
+            if not isinstance(measure, dict):
+                continue
+            inner = measure.get("qDef") or {}
+            measures.append({
+                "expression": (inner.get("qDef") or "") if isinstance(inner, dict) else "",
+                "label": (inner.get("qLabel") or "") if isinstance(inner, dict) else "",
+                "library_id": measure.get("qLibraryId")
+                              or (inner.get("qLibraryId") if isinstance(inner, dict) else None),
+            })
+
+        dimensions = []
+        for dimension in cube.get("qDimensions", []) or []:
+            if not isinstance(dimension, dict):
+                continue
+            inner = dimension.get("qDef") or {}
+            dimensions.append({
+                "fields": (inner.get("qFieldDefs") or []) if isinstance(inner, dict) else [],
+                "label": ((inner.get("qFieldLabels") or [""])[0]
+                          if isinstance(inner, dict) and inner.get("qFieldLabels") else ""),
+                "library_id": dimension.get("qLibraryId")
+                              or (inner.get("qLibraryId") if isinstance(inner, dict) else None),
+            })
+
+        return {"measures": measures, "dimensions": dimensions}
+
+    def _resolve_library_items(self, app_handle: int,
+                               expressions_by_index: Dict[int, Dict[str, Any]]) -> None:
+        """Fill in the expressions of master measures and dimensions.
+
+        A chart built from the library stores only `qLibraryId`, so without
+        this step exactly the charts a modeller took the trouble to
+        standardise are the ones reporting no fields.
+        """
+        wanted_measures, wanted_dimensions = [], []
+        for entry in expressions_by_index.values():
+            for measure in entry["measures"]:
+                if measure.get("library_id") and not measure.get("expression"):
+                    wanted_measures.append(measure["library_id"])
+            for dimension in entry["dimensions"]:
+                if dimension.get("library_id") and not dimension.get("fields"):
+                    wanted_dimensions.append(dimension["library_id"])
+
+        wanted_measures = list(dict.fromkeys(wanted_measures))
+        wanted_dimensions = list(dict.fromkeys(wanted_dimensions))
+        if not wanted_measures and not wanted_dimensions:
+            return
+
+        try:
+            handles = self.send_requests_pipelined(
+                [{"method": "GetMeasure", "params": {"qId": lib_id}, "handle": app_handle}
+                 for lib_id in wanted_measures]
+                + [{"method": "GetDimension", "params": {"qId": lib_id}, "handle": app_handle}
+                   for lib_id in wanted_dimensions],
+                raise_on_error=False,
+            )
+        except Exception as exc:
+            logger.debug("Could not resolve master items: %s", exc)
+            return
+
+        resolved_handles = []
+        for outcome in handles:
+            if isinstance(outcome, Exception):
+                resolved_handles.append(None)
+                continue
+            resolved_handles.append(((outcome or {}).get("qReturn") or {}).get("qHandle"))
+
+        layout_indices = [i for i, h in enumerate(resolved_handles) if h is not None]
+        try:
+            layouts = self.send_requests_pipelined(
+                [{"method": "GetLayout", "params": [], "handle": resolved_handles[i]}
+                 for i in layout_indices],
+                raise_on_error=False,
+            ) if layout_indices else []
+        except Exception as exc:
+            logger.debug("Could not read master item layouts: %s", exc)
+            return
+
+        measure_expressions: Dict[str, str] = {}
+        dimension_fields: Dict[str, List[str]] = {}
+        for position, layout in zip(layout_indices, layouts):
+            if isinstance(layout, Exception):
+                continue
+            body = (layout or {}).get("qLayout") or {}
+            if position < len(wanted_measures):
+                lib_id = wanted_measures[position]
+                measure_expressions[lib_id] = ((body.get("qMeasure") or {}).get("qDef") or "")
+            else:
+                lib_id = wanted_dimensions[position - len(wanted_measures)]
+                dimension_fields[lib_id] = ((body.get("qDim") or {}).get("qFieldDefs") or [])
+
+        for entry in expressions_by_index.values():
+            for measure in entry["measures"]:
+                lib_id = measure.get("library_id")
+                if lib_id and not measure.get("expression"):
+                    measure["expression"] = measure_expressions.get(lib_id, "")
+            for dimension in entry["dimensions"]:
+                lib_id = dimension.get("library_id")
+                if lib_id and not dimension.get("fields"):
+                    dimension["fields"] = dimension_fields.get(lib_id, [])
 
     def _extract_fields_from_object(self, obj_layout: Dict[str, Any]) -> List[str]:
         """Extract field names used in an object layout.
@@ -235,15 +455,30 @@ class EngineSheetsMixin:
 
         fields = set(re.findall(r"\[([^\]]+)\]", expression))
 
-        # Drop string literals first — 'Sales' inside a set expression is a
-        # value, not a field.
-        without_literals = re.sub(r"'[^']*'", " ", expression)
-        # And bracketed names, already collected above.
-        without_literals = re.sub(r"\[[^\]]*\]", " ", without_literals)
+        text = expression
+        # Dollar expansion is resolved by Qlik before evaluation; the name
+        # inside is a variable, not a field.
+        text = re.sub(r"\$\([^)]*\)", " ", text)
+        # Both quote styles are values inside a set modifier: single quotes
+        # are a literal, double quotes are a *search* —
+        # `Country={"New Zealand"}` matched "New" and "Zealand" as fields
+        # until this line existed.
+        text = re.sub(r"'[^']*'", " ", text)
+        text = re.sub(r'"[^"]*"', " ", text)
+        # Bracketed names, already collected above.
+        text = re.sub(r"\[[^\]]*\]", " ", text)
 
-        for match in re.finditer(r"\b([A-Za-z_][A-Za-z0-9_.]*)\s*(\()?", without_literals):
+        # Field names are routinely non-Latin — `Год` and `Месяц` are the
+        # dimensions of a chart on the stand this was measured against — so
+        # the identifier pattern has to be Unicode-aware rather than A-Za-z.
+        for match in re.finditer(r"(?<![\w.])(\w[\w.]*)\s*(\()?", text, re.UNICODE):
             name, is_call = match.group(1), match.group(2)
             if is_call or name.lower() in _EXPRESSION_KEYWORDS:
+                continue
+            # A name cannot start with a digit in an unbracketed reference,
+            # so anything that does is a literal — including the scientific
+            # notation `1e3`, which was being reported as a field.
+            if name[0].isdigit():
                 continue
             fields.add(name)
 

--- a/qlik_sense_mcp_server/tools/engine.py
+++ b/qlik_sense_mcp_server/tools/engine.py
@@ -820,15 +820,19 @@ def get_app_sheet_objects(app_id: str, sheet_id: str) -> str:
 
     Returns:
         JSON with `objects` array where each element has `object_id`,
-        `object_type` (e.g. `"barchart"`, `"table"`, `"kpi"`, `"listbox"`)
-        and `object_description` (title). Use `object_id` in `get_app_object`.
-    
+        `object_type` (e.g. `"barchart"`, `"table"`, `"kpi"`, `"listbox"`),
+        `object_description` (title) and `fields_used` — the fields the
+        object's dimensions and measures refer to, which answers "what does
+        this sheet work with" without opening every object. Use `object_id`
+        in `get_app_object` for the full layout.
+
     Example:
         Call: {"app_id": "a1b2...", "sheet_id": "b2c3d4e5-1111-..."}
         Returns: {"tool_call_seconds": 1.1, "total_objects": 2,
                   "objects": [{"object_id": "AbCdEf",
                                "object_type": "barchart",
-                               "object_description": "Sales by Region"}]}
+                               "object_description": "Sales by Region",
+                               "fields_used": ["Region", "Sales"]}]}
 
     Qlik session limit: this server keeps ONE Engine session for all
     calls. Qlik allows max 5 concurrent sessions per user and may LOCK
@@ -843,7 +847,17 @@ def get_app_sheet_objects(app_id: str, sheet_id: str) -> str:
         app_handle = context.engine_api.ensure_app(app_id, no_data=False)
         objects = context.engine_api._get_sheet_objects_detailed(app_handle, sheet_id) or []
         formatted = [
-            {"object_id": o.get("object_id", ""), "object_type": o.get("object_type", ""), "object_description": o.get("object_title", "")}
+            {"object_id": o.get("object_id", ""),
+             "object_type": o.get("object_type", ""),
+             "object_description": o.get("object_title", ""),
+             # Already computed while reading each object's layout and
+             # properties. Dropping any of it meant answering "which fields
+             # does this sheet work with" took one get_app_object call per
+             # object — and the expressions were not reachable at all, since
+             # the layout get_app_object returns does not contain them.
+             "fields_used": o.get("fields_used", []),
+             "measures": o.get("measures", []),
+             "dimensions": o.get("dimensions", [])}
             for o in objects if isinstance(o, dict)
         ]
         return _ok({"app_id": app_id, "sheet_id": sheet_id, "total_objects": len(formatted), "objects": formatted})
@@ -872,10 +886,15 @@ def get_app_object(app_id: str, object_id: str) -> str:
         object_id: Object ID from `get_app_sheet_objects`. Required.
 
     Returns:
-        JSON with full `qLayout` of the object. Key fields depend on the
-        object type — look for `qHyperCube.qDimensionInfo`, `qMeasureInfo`,
-        `qDataPages[0].qMatrix` for charts/tables.
-    
+        JSON with the full `qLayout` of the object, plus `measures`,
+        `dimensions` and `fields_used`. Read the expressions from
+        `measures` — Engine does NOT put them in the layout, where
+        `qMeasureInfo` carries only the fallback title, formatting and
+        statistics. Master measures and dimensions are resolved to their
+        library definitions. In the layout itself, look for
+        `qHyperCube.qDimensionInfo` and `qDataPages[0].qMatrix` for the
+        computed data.
+
     Example:
         Call: {"app_id": "a1b2...", "object_id": "AbCdEf"}
         Returns: {"tool_call_seconds": 1.4,
@@ -916,6 +935,30 @@ def get_app_object(app_id: str, object_id: str) -> str:
         if "qLayout" not in layout_result:
             return _err("Failed to get object layout",
                         error_category="engine_api_error")
+        # The layout does not contain the measure expressions — Engine puts
+        # qFallbackTitle, formatting and statistics in qMeasureInfo and
+        # nothing else. Since reverse-engineering a chart is what this tool
+        # is for, fetch the properties too and resolve any master items.
+        try:
+            properties = context.engine_api.send_request(
+                "GetProperties", [], handle=obj_handle)
+            expressions = context.engine_api._object_expressions(properties)
+            by_index = {0: expressions}
+            context.engine_api._resolve_library_items(app_handle, by_index)
+            layout_result["measures"] = expressions["measures"]
+            layout_result["dimensions"] = expressions["dimensions"]
+            layout_result["fields_used"] = sorted(
+                set(context.engine_api._extract_fields_from_object(layout_result["qLayout"]))
+                | {f for m in expressions["measures"]
+                   for f in context.engine_api._extract_fields_from_expression(
+                       m.get("expression", ""))}
+                | {f for d in expressions["dimensions"] for f in d.get("fields", [])}
+            )
+        except Exception as prop_error:
+            # The layout is still worth returning; say what is missing
+            # rather than pretending the object has no measures.
+            logger.warning("GetProperties failed for %s: %s", object_id, prop_error)
+            layout_result["properties_error"] = str(prop_error)
         return _ok(layout_result)
     except Exception as ex:
         return _err(str(ex), app_id=app_id, object_id=object_id)

--- a/tests/test_cube_validation.py
+++ b/tests/test_cube_validation.py
@@ -1,0 +1,223 @@
+"""Queries Qlik answers with a number instead of an error.
+
+Qlik evaluates an unknown name as an expression worth 0 and never says so.
+Measured on 31.62 against a 10M-row app: a cube grouped by `no_such_field`
+came back as one row holding 49,989,556,885.52 — the grand total over all
+ten regions, indistinguishable from a real answer. A measure filtered on
+`region_name={'Moscow'}` where the data says `Moskva` returned a full,
+well-formed table of zeros.
+
+Nothing downstream can recover from that: the rows are valid JSON, the
+numbers are plausible, and the model reports them as fact. So the check
+happens here, before the query runs.
+"""
+
+import pytest
+
+from qlik_sense_mcp_server.engine_api import QlikEngineAPI
+
+
+class _Engine(QlikEngineAPI):
+    """Knows a fixed set of field names; records what was asked."""
+
+    def __init__(self, known=("Region", "Sales", "OrderDate", "Category")):
+        self.known = set(known)
+        self.checked = []
+
+    def send_requests_pipelined(self, requests, raise_on_error=True):
+        outcomes = []
+        for request in requests:
+            name = request["params"][0]
+            self.checked.append(name)
+            if name in self.known:
+                outcomes.append({"qReturn": {"qName": name, "qCardinal": 10}})
+            else:
+                outcomes.append(Exception("Invalid parameters"))
+        return outcomes
+
+    def get_fields(self, app_handle):
+        # The Engine layer's own key name — the tool layer is what renames it
+        # to `name`. Getting this wrong made every suggestion list empty.
+        return {"fields": [{"field_name": n} for n in sorted(self.known)]}
+
+
+def _dims(*fields):
+    return [{"field": f} for f in fields]
+
+
+def _measures(*expressions):
+    return [{"expression": e} for e in expressions]
+
+
+class TestUnknownDimension:
+    def test_unknown_field_is_refused(self):
+        result = _Engine()._validate_cube_inputs(1, _dims("Regionn"), _measures("Sum(Sales)"))
+        assert result["error_category"] == "field_not_found"
+        assert result["unknown_fields"] == ["Regionn"]
+
+    def test_a_near_miss_is_suggested(self):
+        result = _Engine()._validate_cube_inputs(1, _dims("Regionn"), [])
+        assert result["did_you_mean"]["Regionn"] == ["Region"]
+
+    def test_known_fields_pass(self):
+        result = _Engine()._validate_cube_inputs(1, _dims("Region"), _measures("Sum(Sales)"))
+        assert "error" not in result
+        assert result["warnings"] == []
+
+    def test_brackets_are_stripped_before_checking(self):
+        result = _Engine()._validate_cube_inputs(1, _dims("[Region]"), [])
+        assert "error" not in result
+
+    def test_a_calculated_dimension_is_not_a_field(self):
+        """`=Year(OrderDate)` is an expression; checking it as a name would
+        refuse a query that works."""
+        engine = _Engine()
+        result = engine._validate_cube_inputs(1, _dims("=Year(OrderDate)"), [])
+        assert "error" not in result
+        assert "=Year(OrderDate)" not in engine.checked
+
+    def test_no_dimensions_is_fine(self):
+        assert "error" not in _Engine()._validate_cube_inputs(1, [], _measures("Sum(Sales)"))
+
+
+class TestMeasureWarnings:
+    def test_unknown_name_in_a_measure_warns_but_does_not_block(self):
+        result = _Engine()._validate_cube_inputs(1, _dims("Region"), _measures("Sum(Salez)"))
+        assert "error" not in result
+        assert any("Salez" in w for w in result["warnings"])
+
+    def test_a_variable_expansion_is_not_treated_as_a_field(self):
+        """`$(vTarget)` is resolved by Qlik; the name inside is not a field."""
+        result = _Engine()._validate_cube_inputs(
+            1, _dims("Region"), _measures("Sum(Sales) / $(vTarget)"))
+        assert result["warnings"] == []
+
+    @pytest.mark.parametrize("expression, fragment", [
+        ("SUM(Sales) AS total", "AS <alias>"),
+        ("SELECT Sum(Sales)", "SELECT"),
+        ("Sum(Sales) GROUP BY Region", "GROUP BY"),
+        ("Sum(Sales) FROM Orders", "FROM"),
+        ("Sum(Sales) WHERE Region='North'", "WHERE"),
+    ])
+    def test_sql_syntax_is_named(self, expression, fragment):
+        result = _Engine()._validate_cube_inputs(1, _dims("Region"), [{"expression": expression}])
+        assert any(fragment in w for w in result["warnings"]), result["warnings"]
+
+    def test_set_analysis_is_not_mistaken_for_sql(self):
+        result = _Engine()._validate_cube_inputs(
+            1, _dims("Region"), _measures("Sum({<Category={'Books'}>} Sales)"))
+        assert result["warnings"] == []
+
+    def test_each_field_is_checked_once(self):
+        engine = _Engine()
+        engine._validate_cube_inputs(
+            1, _dims("Region"), _measures("Sum(Sales)", "Avg(Sales)", "Count(Sales)"))
+        assert engine.checked.count("Sales") == 1
+
+
+class TestEmptyMeasureDetection:
+    COLUMNS = ["Region", "Revenue", "Filtered"]
+
+    def test_an_all_zero_measure_is_reported(self):
+        rows = [["North", 100, 0], ["South", 200, 0]]
+        assert QlikEngineAPI._measure_columns_are_empty(rows, 1, self.COLUMNS) == ["Filtered"]
+
+    def test_a_measure_of_dashes_is_reported(self):
+        """What Qlik returns for an expression it could not evaluate."""
+        rows = [["North", 100, "-"], ["South", 200, "-"]]
+        assert QlikEngineAPI._measure_columns_are_empty(rows, 1, self.COLUMNS) == ["Filtered"]
+
+    def test_one_real_value_is_enough_to_stay_quiet(self):
+        rows = [["North", 100, 0], ["South", 200, 5]]
+        assert QlikEngineAPI._measure_columns_are_empty(rows, 1, self.COLUMNS) == []
+
+    def test_dimension_columns_are_not_measures(self):
+        """A dimension of zeros is data, not a broken expression."""
+        rows = [[0, 100], [0, 200]]
+        assert QlikEngineAPI._measure_columns_are_empty(rows, 1, ["Flag", "Revenue"]) == []
+
+    def test_no_rows_means_nothing_to_say(self):
+        assert QlikEngineAPI._measure_columns_are_empty([], 1, self.COLUMNS) == []
+
+
+class TestSuggestions:
+    """The wrong case is the most common way to miss a field name.
+
+    Qlik field names are case-sensitive, so `REGION_NAME` is a genuine
+    miss — but answering it with no suggestion at all leaves the caller
+    with nothing to act on, when the field is right there.
+    """
+
+    def test_a_different_case_is_suggested(self):
+        engine = _Engine(known=("region_name", "region_code"))
+        result = engine._validate_cube_inputs(1, _dims("REGION_NAME"), [])
+        assert result["did_you_mean"]["REGION_NAME"][0] == "region_name"
+
+    def test_the_suggestion_keeps_the_real_spelling(self):
+        engine = _Engine(known=("OrderDate",))
+        result = engine._validate_cube_inputs(1, _dims("orderdate"), [])
+        assert result["did_you_mean"]["orderdate"] == ["OrderDate"]
+
+    def test_a_join_key_is_suggested_once(self):
+        """The same field in two tables came back three times in the list."""
+        class _Duplicated(_Engine):
+            def get_fields(self, app_handle):
+                return {"fields": [{"field_name": "region_code"},
+                                   {"field_name": "region_code"},
+                                   {"field_name": "region_name"}]}
+
+        result = _Duplicated()._validate_cube_inputs(1, _dims("regioncode"), [])
+        assert result["did_you_mean"]["regioncode"].count("region_code") == 1
+
+    def test_nothing_similar_means_no_key_at_all(self):
+        engine = _Engine(known=("Region",))
+        result = engine._validate_cube_inputs(1, _dims("zzzzzz"), [])
+        assert "zzzzzz" not in result.get("did_you_mean", {})
+
+
+class TestCalculatedDimensions:
+    """`=Year(no_such_field)` used to skip the check entirely.
+
+    A calculated dimension is an expression, so it is not a field name —
+    but the names inside it are, and passing it through unexamined left
+    open the exact hole the check exists to close.
+    """
+
+    def test_a_bad_name_inside_a_calculated_dimension_is_reported(self):
+        result = _Engine()._validate_cube_inputs(
+            1, [{"field": "=Year(OrderDatte)"}], [])
+        assert any("OrderDatte" in w for w in result["warnings"]), result
+
+    def test_a_good_calculated_dimension_is_quiet(self):
+        result = _Engine()._validate_cube_inputs(
+            1, [{"field": "=Year(OrderDate)"}], [])
+        assert result["warnings"] == []
+
+    def test_it_warns_rather_than_refuses(self):
+        """Lexical, so it must not block a query that works."""
+        result = _Engine()._validate_cube_inputs(
+            1, [{"field": "=Year(OrderDatte)"}], [])
+        assert "error" not in result
+
+
+class TestSqlDetectionPrecision:
+    def test_a_field_name_containing_a_keyword_is_not_sql(self):
+        """`[Cost as planned]` is a legal field name, not an alias."""
+        result = _Engine()._validate_cube_inputs(
+            1, _dims("Region"), [{"expression": "Sum([Cost as planned])"}])
+        assert not any("SQL" in w for w in result["warnings"]), result["warnings"]
+
+    def test_a_string_literal_containing_a_keyword_is_not_sql(self):
+        result = _Engine()._validate_cube_inputs(
+            1, _dims("Region"), [{"expression": "Sum(If(Region='North as usual', Sales))"}])
+        assert not any("SQL" in w for w in result["warnings"]), result["warnings"]
+
+    @pytest.mark.parametrize("expression", [
+        'SUM(Sales) AS "total"',
+        "SUM(Sales) AS [total]",
+        "SUM(Sales) AS total",
+    ])
+    def test_every_alias_form_is_caught(self, expression):
+        """A quoted alias is the form a model writes most often."""
+        result = _Engine()._validate_cube_inputs(1, _dims("Region"), [{"expression": expression}])
+        assert any("AS <alias>" in w for w in result["warnings"]), (expression, result["warnings"])

--- a/tests/test_e2e_cube_validation.py
+++ b/tests/test_e2e_cube_validation.py
@@ -1,0 +1,87 @@
+"""Against a real Qlik: the queries that come back wrong instead of failing.
+
+These cannot be faked. The whole point is what Qlik itself does with a
+mistake — and what it does is answer. A cube grouped by a field that does
+not exist returns the grand total as a single row; a measure filtered on a
+value that does not exist returns a full table of zeros. Both are valid
+JSON with plausible numbers, and neither says anything is wrong.
+"""
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.fixture(scope="module")
+def app(request):
+    return os.getenv("QLIK_E2E_APP") or pytest.skip("QLIK_E2E_APP is not set")
+
+
+@pytest.fixture(scope="module")
+def a_real_field(call, app):
+    """Any field with data — the tests below need one that exists."""
+    details = call("get_app_details", app_id=app)
+    fields = [f["name"] for f in details.get("fields", []) if f.get("distinct_values")]
+    if not fields:
+        pytest.skip("the configured app has no fields with data")
+    return fields[0]
+
+
+class TestUnknownDimensionIsRefused:
+    def test_a_misspelled_dimension_does_not_return_a_number(self, raw_call, app):
+        result = raw_call("engine_create_hypercube", app_id=app,
+                          dimensions=["no_such_field_xyz"],
+                          measures=["Count(1)"], limit=5)
+        assert result.get("error_category") == "field_not_found", (
+            f"Qlik answered instead of failing: {result}")
+        assert "no_such_field_xyz" in result.get("unknown_fields", [])
+
+    def test_the_refusal_names_a_real_alternative(self, raw_call, app, a_real_field):
+        """A near miss should point at the field the caller meant."""
+        typo = a_real_field + "x"
+        result = raw_call("engine_create_hypercube", app_id=app,
+                          dimensions=[typo], measures=["Count(1)"], limit=5)
+        assert result.get("error_category") == "field_not_found"
+        assert a_real_field in result.get("did_you_mean", {}).get(typo, []), (
+            f"no suggestion for {typo!r}: {result.get('did_you_mean')}")
+
+    def test_a_real_field_still_works(self, call, app, a_real_field):
+        """The guard must not refuse a query that was always valid."""
+        cube = call("engine_create_hypercube", app_id=app,
+                    dimensions=[a_real_field], measures=["Count(1)"], limit=5)
+        assert cube["rows"], "a valid query returned nothing"
+        assert cube.get("warnings") == []
+
+
+class TestSilentlyEmptyMeasures:
+    def test_a_filter_on_a_value_that_does_not_exist_is_flagged(self, call, app, a_real_field):
+        cube = call("engine_create_hypercube", app_id=app,
+                    dimensions=[a_real_field],
+                    measures=["Count({<%s={'nothing_matches_this'}>} 1)" % a_real_field],
+                    limit=5)
+        assert any("0 or '-'" in w for w in cube.get("warnings", [])), (
+            f"a table of zeros passed without comment: {cube.get('rows')}")
+
+    def test_sql_syntax_is_named_as_such(self, call, app, a_real_field):
+        cube = call("engine_create_hypercube", app_id=app,
+                    dimensions=[a_real_field],
+                    measures=["COUNT(1) AS total"], limit=5)
+        assert any("SQL" in w for w in cube.get("warnings", [])), cube.get("warnings")
+
+    def test_an_unknown_name_inside_a_measure_warns(self, call, app, a_real_field):
+        cube = call("engine_create_hypercube", app_id=app,
+                    dimensions=[a_real_field],
+                    measures=["Sum(no_such_measure_field)"], limit=5)
+        assert any("no_such_measure_field" in w for w in cube.get("warnings", []))
+
+
+class TestValidationCost:
+    def test_the_check_is_cheap(self, call, app, a_real_field):
+        """It runs on every query, so it has to be one pipelined round-trip."""
+        cube = call("engine_create_hypercube", app_id=app,
+                    dimensions=[a_real_field], measures=["Count(1)"], limit=5)
+        validate_seconds = cube.get("timings", {}).get("validate_seconds")
+        assert validate_seconds is not None, "validation step is not timed"
+        assert validate_seconds < 1.0, f"validation took {validate_seconds}s"

--- a/tests/test_hypercube.py
+++ b/tests/test_hypercube.py
@@ -501,3 +501,28 @@ class TestRequestEcho:
         parsed = json.loads(fine("app-3"))
         assert "request" not in parsed
         assert "tool_call_seconds" in parsed
+
+
+class TestEmptyResultIsExplained:
+    """No rows at all is the strongest version of "this measure is empty".
+
+    `suppress_zero=True` turns a full table of zeros into an empty result,
+    and the per-column check needs rows to look at — so the warning went
+    quiet exactly when the answer was emptiest.
+    """
+
+    def test_an_empty_result_is_flagged(self):
+        eng = _PagingEngine(total_rows=0, first_page=0, page_size=3)
+        result = eng.create_hypercube(1, DIMS, MEASURES, 10)
+        assert result["rows"] == []
+        assert any("no rows" in w for w in result["warnings"]), result["warnings"]
+
+    def test_suppress_zero_is_named_as_a_possible_cause(self):
+        eng = _PagingEngine(total_rows=0, first_page=0, page_size=3)
+        result = eng.create_hypercube(1, DIMS, MEASURES, 10, suppress_zero=True)
+        assert any("suppress_zero" in w for w in result["warnings"]), result["warnings"]
+
+    def test_a_result_with_rows_is_not_flagged_as_empty(self):
+        eng = _PagingEngine(total_rows=5, first_page=5, page_size=5)
+        result = eng.create_hypercube(1, DIMS, MEASURES, 10)
+        assert not any("no rows" in w for w in result.get("warnings", []))

--- a/tests/test_pipelining.py
+++ b/tests/test_pipelining.py
@@ -168,8 +168,11 @@ class TestSheetObjectsUsesPipelining:
 
         def fake_pipelined(requests, timeout=None, raise_on_error=True):
             pipelined_calls.append([r["method"] for r in requests])
-            if requests[0]["method"] == "GetObject":
+            method = requests[0]["method"]
+            if method == "GetObject":
                 return [{"qReturn": {"qHandle": 100 + i}} for i in range(len(requests))]
+            if method == "GetProperties":
+                return [{"qProp": {"qHyperCubeDef": {}}} for _ in requests]
             return [{"qLayout": {"title": f"obj{i}"}} for i in range(len(requests))]
 
         eng.send_request = fake_send_request
@@ -180,10 +183,13 @@ class TestSheetObjectsUsesPipelining:
 
         assert len(result) == 3
         assert [r["object_title"] for r in result] == ["obj0", "obj1", "obj2"]
-        # Exactly 2 batched calls total, regardless of how many children.
-        assert len(pipelined_calls) == 2
-        assert pipelined_calls[0] == ["GetObject"] * 3
-        assert pipelined_calls[1] == ["GetLayout"] * 3
+        # The point is that the cost is a constant number of round-trips, not
+        # one per object: handles, layouts and properties, each in one batch.
+        # (Properties are needed because the layout has no measure
+        # expressions — Engine simply does not put them there.)
+        assert [len(batch) for batch in pipelined_calls] == [3, 3, 3]
+        assert [batch[0] for batch in pipelined_calls] == [
+            "GetObject", "GetLayout", "GetProperties"]
 
     def test_one_bad_child_does_not_drop_the_rest(self):
         eng = QlikEngineAPI.__new__(QlikEngineAPI)

--- a/tests/test_sheet_object_fields.py
+++ b/tests/test_sheet_object_fields.py
@@ -109,3 +109,148 @@ class TestExpressions:
         """'North' is a value being compared against, not a column."""
         assert "North" not in engine._extract_fields_from_expression(
             "Sum(If(Region='North', Sales))")
+
+    def test_a_double_quoted_search_is_not_a_field(self, engine):
+        """In a set modifier, double quotes are a search value, not a name.
+
+        `Country={"New Zealand"}` used to report `New` and `Zealand` as two
+        fields of the data model.
+        """
+        assert engine._extract_fields_from_expression(
+            'Sum({<Country={"New Zealand", "C*"}>} Sales)') == ["Country", "Sales"]
+
+    def test_non_latin_field_names_are_found(self, engine):
+        """Real dimensions on the stand this was measured against are
+        `Год` and `Месяц`; an A-Za-z pattern loses every one of them."""
+        assert engine._extract_fields_from_expression(
+            "Count(distinct lara_id) / Sum(Год)") == ["lara_id", "Год"]
+
+    @pytest.mark.parametrize("expression", [
+        "Count(distinct lara_id) / 1e3",
+        "Sum(Sales) * 1.5",
+        "Sum(Sales) / 1000",
+    ])
+    def test_numeric_literals_are_not_fields(self, engine, expression):
+        found = engine._extract_fields_from_expression(expression)
+        assert all(not f[0].isdigit() for f in found), found
+
+    def test_a_variable_expansion_is_not_a_field(self, engine):
+        assert engine._extract_fields_from_expression(
+            "Sum(Sales) / $(vTarget)") == ["Sales"]
+
+
+class TestExpressionsFromProperties:
+    """The layout has no measure expressions — the properties do.
+
+    Measured on 31.62: `qMeasureInfo` in a GetLayout reply carries
+    qFallbackTitle, formatting and statistics, and no `qDef` at all. Reading
+    the expression from the layout therefore found nothing on every real
+    object, while the tests passed against a hand-written layout that had a
+    `qDef` Qlik never sends.
+    """
+
+    def test_inline_measure_and_dimension(self, engine):
+        properties = {"qProp": {"qHyperCubeDef": {
+            "qMeasures": [{"qDef": {"qDef": "Sum(Sales)", "qLabel": "Revenue"}}],
+            "qDimensions": [{"qDef": {"qFieldDefs": ["Region"]}}],
+        }}}
+        parsed = engine._object_expressions(properties)
+        assert parsed["measures"] == [
+            {"expression": "Sum(Sales)", "label": "Revenue", "library_id": None}]
+        assert parsed["dimensions"][0]["fields"] == ["Region"]
+
+    def test_a_master_measure_reports_its_library_id(self, engine):
+        properties = {"qProp": {"qHyperCubeDef": {
+            "qMeasures": [{"qLibraryId": "abc-123", "qDef": {"qDef": ""}}],
+            "qDimensions": [],
+        }}}
+        parsed = engine._object_expressions(properties)
+        assert parsed["measures"][0]["library_id"] == "abc-123"
+        assert parsed["measures"][0]["expression"] == ""
+
+    def test_a_failed_properties_call_is_not_an_object_without_measures(self, engine):
+        assert engine._object_expressions(Exception("boom")) == {
+            "measures": [], "dimensions": []}
+
+    def test_an_object_with_no_hypercube(self, engine):
+        assert engine._object_expressions({"qProp": {}}) == {"measures": [], "dimensions": []}
+
+
+class TestMasterItemResolution:
+    """A chart built from the library stores only an id.
+
+    Without resolving it, the charts a modeller took the trouble to
+    standardise are exactly the ones reporting no fields — which is the
+    wrong way round.
+    """
+
+    class _Engine(QlikEngineAPI):
+        def __init__(self):
+            self.batches = []
+
+        def send_requests_pipelined(self, requests, raise_on_error=True):
+            self.batches.append([r["method"] for r in requests])
+            method = requests[0]["method"]
+            if method in ("GetMeasure", "GetDimension"):
+                return [{"qReturn": {"qHandle": 10 + i}} for i in range(len(requests))]
+            if method == "GetLayout":
+                # Handles were handed out in request order: measures first.
+                return [{"qLayout": {"qMeasure": {"qDef": "Sum(Sales)"}}},
+                        {"qLayout": {"qDim": {"qFieldDefs": ["Region"]}}}][:len(requests)]
+            raise AssertionError(method)
+
+    def test_library_measure_and_dimension_are_filled_in(self):
+        engine = self._Engine()
+        entries = {0: {
+            "measures": [{"expression": "", "label": "", "library_id": "m-1"}],
+            "dimensions": [{"fields": [], "label": "", "library_id": "d-1"}],
+        }}
+        engine._resolve_library_items(1, entries)
+        assert entries[0]["measures"][0]["expression"] == "Sum(Sales)"
+        assert entries[0]["dimensions"][0]["fields"] == ["Region"]
+
+    def test_nothing_to_resolve_costs_no_calls(self):
+        engine = self._Engine()
+        entries = {0: {"measures": [{"expression": "Sum(Sales)", "library_id": None}],
+                       "dimensions": []}}
+        engine._resolve_library_items(1, entries)
+        assert engine.batches == []
+
+    def test_the_same_library_id_is_fetched_once(self):
+        engine = self._Engine()
+        entries = {
+            0: {"measures": [{"expression": "", "library_id": "m-1"}], "dimensions": []},
+            1: {"measures": [{"expression": "", "library_id": "m-1"}], "dimensions": []},
+        }
+        engine._resolve_library_items(1, entries)
+        assert engine.batches[0] == ["GetMeasure"]
+
+
+class TestContainerChildren:
+    """A filter pane holds no fields itself; its listbox children do."""
+
+    class _Engine(QlikEngineAPI):
+        def __init__(self):
+            pass
+
+        def send_requests_pipelined(self, requests, raise_on_error=True):
+            if requests[0]["method"] == "GetObject":
+                return [{"qReturn": {"qHandle": 50 + i}} for i in range(len(requests))]
+            return [
+                {"qLayout": {"qListObject": {"qDimensionInfo": {"qGroupFieldDefs": [name]}}}}
+                for name in ("Region", "Year")
+            ][:len(requests)]
+
+    def test_children_contribute_their_fields_to_the_parent(self):
+        engine = self._Engine()
+        layouts = {0: {"qLayout": {"qChildList": {"qItems": [
+            {"qInfo": {"qId": "lb1"}}, {"qInfo": {"qId": "lb2"}}]}}}}
+        assert sorted(engine._nested_object_fields(1, layouts)[0]) == ["Region", "Year"]
+
+    def test_an_object_without_children_asks_nothing(self):
+        engine = self._Engine()
+        assert engine._nested_object_fields(1, {0: {"qLayout": {"qHyperCube": {}}}}) == {}
+
+    def test_a_failed_layout_is_skipped(self):
+        engine = self._Engine()
+        assert engine._nested_object_fields(1, {0: Exception("gone")}) == {}

--- a/tests/test_ws_scheme.py
+++ b/tests/test_ws_scheme.py
@@ -75,16 +75,23 @@ class TestScheme:
         tried = _connect_and_capture(_client(url), app_id="app-1")
         assert tried[0][0].startswith(expected), tried[0][0]
 
-    def test_every_fallback_endpoint_uses_the_same_scheme(self):
-        """A wss:// fallback after a ws:// first try would fail confusingly."""
+    def test_every_endpoint_tried_uses_the_configured_scheme(self):
+        """Not just the first one: if the first URL fails, the retries must
+        not silently switch to TLS against a server that has none."""
         client = _client("http://qlik.example.com/jwt")
         client.ws_retries = 5
-        tried = _connect_and_capture(client, app_id="app-1")
-        # Only the first succeeds here, so force the failure path instead.
-        with patch("websocket.create_connection", side_effect=OSError("refused")):
+        tried = []
+
+        def always_refused(url, **kwargs):
+            tried.append(url)
+            raise OSError("connection refused")
+
+        with patch("websocket.create_connection", side_effect=always_refused):
             with pytest.raises(Exception):
                 client.connect(app_id="app-1")
-        assert all(url.startswith("ws://") for url, _ in tried)
+
+        assert len(tried) > 1, "only one endpoint was tried; the test proves nothing"
+        assert all(url.startswith("ws://") for url in tried), tried
 
 
 class TestHeaders:
@@ -105,3 +112,54 @@ class TestHeaders:
         tried = _connect_and_capture(_client("https://qlik.example.com/jwt"))
         assert not any(h.lower().startswith("authorization")
                        for h in tried[0][1]["header"])
+
+
+class TestCertificateMode:
+    """The other authentication mode obeys the same contract.
+
+    Certificate mode connects straight to the Engine port instead of going
+    through a virtual proxy, but `QLIK_SERVER_URL` is still where the
+    operator states the scheme. It used to list both `wss://` endpoints
+    first and only then `ws://`, and since the default retry budget is 2,
+    the `ws://` entries were unreachable — on a node whose Engine TLS is
+    unhappy, the client failed with no way to ask for plain WebSocket.
+    """
+
+    @staticmethod
+    def _cert_client(server_url):
+        config = QlikSenseConfig(server_url=server_url,
+                                 user_directory="QLIK1", user_id="svc")
+        return QlikEngineAPI(config)
+
+    def test_http_url_tries_ws_first(self):
+        tried = _connect_and_capture(self._cert_client("http://qlik.example.com"))
+        assert tried[0][0].startswith("ws://"), tried[0][0]
+
+    def test_https_url_tries_wss_first(self):
+        tried = _connect_and_capture(self._cert_client("https://qlik.example.com"))
+        assert tried[0][0].startswith("wss://"), tried[0][0]
+
+    def test_the_engine_port_is_used(self):
+        tried = _connect_and_capture(self._cert_client("https://qlik.example.com"))
+        assert ":4747/" in tried[0][0], tried[0][0]
+
+    def test_the_requested_scheme_is_exhausted_before_the_other(self):
+        client = self._cert_client("http://qlik.example.com")
+        client.ws_retries = 2  # the default budget
+        tried = []
+
+        def always_refused(url, **kwargs):
+            tried.append(url)
+            raise OSError("connection refused")
+
+        with patch("websocket.create_connection", side_effect=always_refused):
+            with pytest.raises(Exception):
+                client.connect()
+
+        assert tried, "nothing was tried"
+        assert all(url.startswith("ws://") for url in tried), tried
+
+    def test_identity_header_is_sent(self):
+        tried = _connect_and_capture(self._cert_client("https://qlik.example.com"))
+        headers = tried[0][1]["header"]
+        assert any("X-Qlik-User: UserDirectory=QLIK1; UserId=svc" == h for h in headers)


### PR DESCRIPTION
Qlik does not report a mistake in a query — it evaluates it. Measured on 31.62 against a 10M-row app:

| What was written | What Qlik returned |
|---|---|
| dimension `no_such_field` | one row holding 49,989,556,885.52 — the grand total over all ten regions |
| `Sum(no_such_field)` | zeros for every group |
| `region_name={'Moscow'}` where the data says `Moskva` | a full, well-formed table of zeros |
| `SUM(amount) AS total` | every value `'-'` |

All four are valid JSON with plausible numbers and no indication that anything went wrong — the worst failure mode there is for a model that will quote them as fact.

**What this release does about it.** Dimension fields are verified against the data model before the cube is built (one pipelined `GetFieldDescription` batch, ~10ms) and an unknown one is refused with `did_you_mean` suggestions, matched case-insensitively since the wrong case is the most common miss. Measures get `warnings` rather than errors — the names inside them are found lexically and a false positive must not block a working query — covering an all-zero measure column, SQL syntax, names the model does not have, and an empty result (which is what `suppress_zero` turns a table of zeros into).

**Found while measuring that:** the sheet-object reader was looking for measure expressions in the object layout, and Engine does not put them there. Verified against a live sheet: every measure arrives with `qFallbackTitle`, formatting and statistics, and no `qDef`. The definitions are in the properties, now fetched in the same pipelined pass; master items are resolved through `GetMeasure`/`GetDimension`, so the charts a modeller standardised stop being the ones reporting no fields; and filter panes needed one level deeper, since they are containers whose listbox children hold the fields.

The extractor itself was Latin-only — a chart grouped by `Год` and `Месяц` contributed nothing — reported `1e3` as a field, and turned a double-quoted set-analysis search into field names.

Certificate mode now follows the URL scheme too; 1.8.1 fixed that for JWT only.

**Reviewed** by three independent reviewers; six findings, all confirmed against the code and fixed here.

**Verified:** 445 offline tests, 58 e2e against a live Qlik 31.62.